### PR TITLE
bump nginx[:version] attribute to "1.0.14"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-default[:nginx][:version] = "1.0.12"
+default[:nginx][:version] = "1.0.14"
 default[:nginx][:url]     = "http://nginx.org/download/nginx-#{node[:nginx][:version]}.tar.gz"
 
 case platform


### PR DESCRIPTION
nginx 1.0.14 was released with security fixes:
    http://nginx.org/en/CHANGES-1.0
