### PR TITLE
COOK-1020: nginx complains about duplicate MIME type

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,7 +46,6 @@ default[:nginx][:gzip_comp_level]   = "2"
 default[:nginx][:gzip_proxied]      = "any"
 default[:nginx][:gzip_types]        = [
   "text/plain",
-  "text/html",
   "text/css",
   "application/x-javascript",
   "text/xml",


### PR DESCRIPTION
nginx gives a warning on startup because text/html is included in gzip types by default.
