### PR TITLE
stop depending on bluepill, runit and yum. they are not required

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,8 +11,12 @@ recipe "nginx::source", "Installs nginx from source and sets up configuration wi
   supports os
 end
 
-%w{ build-essential runit bluepill yum }.each do |cb|
+%w{ build-essential }.each do |cb|
   depends cb
+end
+
+%w{ yum runit bluepill }.each do |cb|
+  recommends cb
 end
 
 depends 'ohai', '~> 1.0.2'


### PR DESCRIPTION
these are not actually required for using the nginx cookbook on all platforms.
