### PR TITLE
fix ambiguity of nginx['version'] for nginx::source

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ From: http://wiki.nginx.org/HttpRealIpModule
 
 These attributes are used in the `nginx::source` recipe. Some of them are dynamically modified during the run. See `attributes/source.rb` for default values.
 
-* `node['nginx']['source']['url']` - (versioned) URL for the Nginx source code. By default this will use the version specified as `node['nginx']['version'].
+* `node['nginx']['source']['version'] - which version of nginx to compile.
+* `node['nginx']['source']['url']` - (versioned) URL for the Nginx source code. By default this will use the version specified as `node['nginx']['source']['version'].
 * `node['nginx']['source']['prefix']` - (versioned) prefix for installing nginx from source
 * `node['nginx']['source']['conf_path']` - location of the main config file, in `node['nginx']['dir']` by default.
 * `node['nginx']['source']['modules']` - Array of modules that should be compiled into Nginx by including their recipes in `nginx::source`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,6 @@
 # limitations under the License.
 #
 
-default['nginx']['version'] = "1.0.14"
 default['nginx']['dir'] = "/etc/nginx"
 default['nginx']['log_dir'] = "/var/log/nginx"
 default['nginx']['binary'] = "/usr/sbin/nginx"

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -19,7 +19,9 @@
 # limitations under the License.
 #
 
-set['nginx']['source']['prefix']                  = "/opt/nginx-#{node['nginx']['version']}"
+default['nginx']['source']['version'] = "1.0.14"
+
+set['nginx']['source']['prefix']                  = "/opt/nginx-#{node['nginx']['source']['version']}"
 set['nginx']['source']['conf_path']               = "#{node['nginx']['dir']}/nginx.conf"
 set['nginx']['source']['default_configure_flags'] = [
   "--prefix=#{node['nginx']['source']['prefix']}",
@@ -27,7 +29,7 @@ set['nginx']['source']['default_configure_flags'] = [
 ]
 
 default['nginx']['configure_flags']  = Array.new
-default['nginx']['source']['url']     = "http://nginx.org/download/nginx-#{node['nginx']['version']}.tar.gz"
+default['nginx']['source']['url']     = "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
 default['nginx']['source']['modules'] = [
   "http_ssl_module",
   "http_gzip_static_module"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -23,10 +23,10 @@
 
 
 nginx_url = node['nginx']['source']['url'] ||
-  "http://nginx.org/download/nginx-#{node['nginx']['version']}.tar.gz"
+  "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
 
 unless(node['nginx']['source']['prefix'])
-  node.set['nginx']['source']['prefix'] = "/opt/nginx-#{node['nginx']['version']}"
+  node.set['nginx']['source']['prefix'] = "/opt/nginx-#{node['nginx']['source']['version']}"
 end
 unless(node['nginx']['source']['conf_path'])
   node.set['nginx']['source']['conf_path'] = "#{node['nginx']['dir']}/nginx.conf"
@@ -43,7 +43,7 @@ node.set['nginx']['daemon_disable']  = true
 include_recipe "nginx::ohai_plugin"
 include_recipe "build-essential"
 
-src_filepath  = "#{Chef::Config['file_cache_path'] || '/tmp'}/nginx-#{node['nginx']['version']}.tar.gz"
+src_filepath  = "#{Chef::Config['file_cache_path'] || '/tmp'}/nginx-#{node['nginx']['source']['version']}.tar.gz"
 packages = value_for_platform(
     ["centos","redhat","fedora"] => {'default' => ['pcre-devel', 'openssl-devel']},
     "default" => ['libpcre3', 'libpcre3-dev', 'libssl-dev']
@@ -80,14 +80,14 @@ bash "compile_nginx_source" do
   cwd ::File.dirname(src_filepath)
   code <<-EOH
     tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)}
-    cd nginx-#{node['nginx']['version']} && ./configure #{node.run_state['nginx_configure_flags'].join(" ")}
+    cd nginx-#{node['nginx']['source']['version']} && ./configure #{node.run_state['nginx_configure_flags'].join(" ")}
     make && make install
     rm -f #{node['nginx']['dir']}/nginx.conf
   EOH
   
   not_if do
     nginx_force_recompile == false &&
-      node.automatic_attrs['nginx']['version'] == node['nginx']['version'] &&
+      node.automatic_attrs['nginx']['version'] == node['nginx']['source']['version'] &&
       node.automatic_attrs['nginx']['configure_arguments'].sort == configure_flags.sort
   end
 end


### PR DESCRIPTION
`node['nginx']['version']` is an automatic_attribute (via ohai plugin), and it is nil when this cookbook is first used.

At first run of the cookbook, empty `node['nginx']['version']` causes installed folder `/opt/nginx-` to be used by nginx::source instead of `/opt/nginx-1.0.14` (1.0.14 is the default version).

Later, when `node['nginx']['version']` is used on subsequent runs, its value is stored in ohai via the plugin. Changing the value in a role, or node override attribute has no effect and will not upgrade the existing version.

This change creates a specific attribute called `node['nginx']['source']['version']`, used to force `nginx::source` to upgrade the version. And it prevents the conflict with the ohai automatic `node['nginx']['version']`.
