### PR TITLE
compile nginx with http_sub_module

### DIFF
--- a/recipes/http_sub_module.rb
+++ b/recipes/http_sub_module.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: http_sub_module
+#
+# Author:: Alessandro Di Maria
+#
+# Copyright 2012, Alessandro Di Maria
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.run_state['nginx_configure_flags'] =
+  node.run_state['nginx_configure_flags'] | ["--with-http_sub_module"]


### PR DESCRIPTION
Additional recipe to compile nginx with http_sub_module

for example:

``` jason
"nginx": {
    "version": "1.2.3",
    "source": {
      "modules": [
        "http_ssl_module",
        "http_gzip_static_module",
        "http_sub_module"
    ]
  }
}
```
