### PR TITLE
COOK-1735 - Support Amazon Linux in nginx::source recipe

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -45,7 +45,7 @@ include_recipe "build-essential"
 
 src_filepath  = "#{Chef::Config['file_cache_path'] || '/tmp'}/nginx-#{node['nginx']['version']}.tar.gz"
 packages = value_for_platform(
-    ["centos","redhat","fedora"] => {'default' => ['pcre-devel', 'openssl-devel']},
+    ["centos","redhat","fedora","amazon"] => {'default' => ['pcre-devel', 'openssl-devel']},
     "default" => ['libpcre3', 'libpcre3-dev', 'libssl-dev']
   )
 


### PR DESCRIPTION
Currently, the source recipe in the nginx cookbook does not support Amazon Linux as a platform.

http://tickets.opscode.com/browse/COOK-1735
