### PR TITLE
Source fix

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,1 +1,0 @@
-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-Berksfilesource "http://rubygems.org"
+source :rubygems
 
-gem 'thor-foodcritic', '~> 0.1.2'
-gem 'berkshelf', '~> 0.3.0'
-gem 'thor-scmversion', '~> 0.0.3'
+gem 'test-kitchen'

--- a/Thorfile
+++ b/Thorfile
@@ -1,7 +1,0 @@
-# encoding: utf-8
-
-require 'bundler'
-require 'bundler/setup'
-require 'thor/foodcritic'
-require 'thor/scmversion'
-require 'berkshelf/thor'

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ end
   depends cb
 end
 
-depends 'ohai', '>= 1.0.2'
+depends 'ohai', '>= 1.1.0'
 
 attribute "nginx/dir",
   :display_name => "Nginx Directory",


### PR DESCRIPTION
Fixes the issue of nginx not correctly building from the correct source url.  Source version to build from is now namespaced to `node['nginx']['source']['version']` rather than `node['nginx']['version']` which seemed to be getting populated by o'hai.
