### PR TITLE
COOK-1770 Check that the system has a 'cpu' attribute before setting the...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,7 +61,7 @@ default['nginx']['gzip_types']        = [
 
 default['nginx']['keepalive']          = "on"
 default['nginx']['keepalive_timeout']  = 65
-default['nginx']['worker_processes']   = cpu['total']
+default['nginx']['worker_processes']   = node['cpu'] ? node['cpu']['total'] : 1
 default['nginx']['worker_connections'] = 1024
 default['nginx']['server_names_hash_bucket_size'] = 64
 


### PR DESCRIPTION
Recipe fails on systems (like Mac OS X) where Ohai can't enumerate the # of CPUs yet. Check that the system has a 'cpu' attribute before setting this attribute. If not, assume "1".
