### PR TITLE
Make dirs, configs and init scripts before running modules recipes.

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -71,33 +71,6 @@ node.run_state['nginx_force_recompile'] = false
 node.run_state['nginx_configure_flags'] =
   node['nginx']['source']['default_configure_flags'] | node['nginx']['configure_flags']
 
-node['nginx']['source']['modules'].each do |ngx_module|
-  include_recipe "nginx::#{ngx_module}"
-end
-
-configure_flags = node.run_state['nginx_configure_flags']
-nginx_force_recompile = node.run_state['nginx_force_recompile']
-
-bash "compile_nginx_source" do
-  cwd ::File.dirname(src_filepath)
-  code <<-EOH
-    tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)}
-    cd nginx-#{node['nginx']['version']} && ./configure #{node.run_state['nginx_configure_flags'].join(" ")}
-    make && make install
-    rm -f #{node['nginx']['dir']}/nginx.conf
-  EOH
-
-  not_if do
-    nginx_force_recompile == false &&
-      node.automatic_attrs['nginx'] &&
-      node.automatic_attrs['nginx']['version'] == node['nginx']['version'] &&
-      node.automatic_attrs['nginx']['configure_arguments'].sort == configure_flags.sort
-  end
-end
-
-node.run_state.delete(:nginx_configure_flags)
-node.run_state.delete(:nginx_force_recompile)
-
 case node['nginx']['init_style']
 when "runit"
   node.set['nginx']['src_binary'] = node['nginx']['binary']
@@ -176,6 +149,33 @@ cookbook_file "#{node['nginx']['dir']}/mime.types" do
   mode "0644"
   notifies :reload, 'service[nginx]', :immediately
 end
+
+node['nginx']['source']['modules'].each do |ngx_module|
+  include_recipe "nginx::#{ngx_module}"
+end
+
+configure_flags = node.run_state['nginx_configure_flags']
+nginx_force_recompile = node.run_state['nginx_force_recompile']
+
+bash "compile_nginx_source" do
+  cwd ::File.dirname(src_filepath)
+  code <<-EOH
+    tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)}
+    cd nginx-#{node['nginx']['version']} && ./configure #{node.run_state['nginx_configure_flags'].join(" ")}
+    make && make install
+    rm -f #{node['nginx']['dir']}/nginx.conf
+  EOH
+
+  not_if do
+    nginx_force_recompile == false &&
+      node.automatic_attrs['nginx'] &&
+      node.automatic_attrs['nginx']['version'] == node['nginx']['version'] &&
+      node.automatic_attrs['nginx']['configure_arguments'].sort == configure_flags.sort
+  end
+end
+
+node.run_state.delete(:nginx_configure_flags)
+node.run_state.delete(:nginx_force_recompile)
 
 service "nginx" do
   action :start


### PR DESCRIPTION
When making nginx from source module recipes depends on created dirs and init scripts. Fixed ordering solves the issue. It refers to [COOK-1787](]http://tickets.opscode.com/browse/COOK-1787).
