### PR TITLE
Fixed Ohai 'nginx -V' command running

### DIFF
--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -19,14 +19,21 @@
 # limitations under the License.
 #
 
+ohai "reload_nginx" do
+  action :nothing
+  plugin "nginx"
+end
+
 template "#{node['ohai']['plugin_path']}/nginx.rb" do
   source "plugins/nginx.rb.erb"
   owner "root"
   group "root"
   mode 0755
   variables(
-    :nginx_bin => node['nginx']['binary']
+    :nginx_prefix => node['nginx']['source']['prefix'],
+    :nginx_bin => 'sbin/nginx'
   )
+  notifies :reload, resources(:ohai => "reload_nginx"), :immediately
 end
 
 include_recipe "ohai"

--- a/templates/default/plugins/nginx.rb.erb
+++ b/templates/default/plugins/nginx.rb.erb
@@ -44,7 +44,7 @@ nginx[:configure_arguments] = Array.new unless nginx[:configure_arguments]
 nginx[:prefix]              = nil unless nginx[:prefix]
 nginx[:conf_path]           = nil unless nginx[:conf_path]
 
-status, stdout, stderr = run_command(:no_status_check => true, :command => "<%= @nginx_bin %> -V")
+status, stdout, stderr = run_command(:no_status_check => true, :cwd => "<%= @nginx_prefix %>", :command => "<%= @nginx_bin %> -V")
 
 if status == 0
   stderr.split("\n").each do |line|


### PR DESCRIPTION
Fixed Ohai 'nginx -V' command running.
Ohai [runs](https://github.com/opscode/ohai/blob/master/lib/ohai/mixin/command.rb#L43) command in Dir.tmpdir and it breakes fetching nginx compilation arguments in recipe.
Closes COOK-1766.
