### PR TITLE
[COOK-1969] - Stringify nginx_configure_flags

### DIFF
--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -62,5 +62,5 @@ template "#{node["nginx"]["dir"]}/conf.d/passenger.conf" do
   notifies :reload, "service[nginx]"
 end
 
-node.run_state[:nginx_configure_flags] =
-  node.run_state[:nginx_configure_flags] | ["--add-module=#{node["nginx"]["passenger"]["root"]}/ext/nginx"]
+node.run_state['nginx_configure_flags'] =
+  node.run_state['nginx_configure_flags'] | ["--add-module=#{node["nginx"]["passenger"]["root"]}/ext/nginx"]

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -96,8 +96,8 @@ bash "compile_nginx_source" do
   end
 end
 
-node.run_state.delete(:nginx_configure_flags)
-node.run_state.delete(:nginx_force_recompile)
+node.run_state.delete('nginx_configure_flags')
+node.run_state.delete('nginx_force_recompile')
 
 case node['nginx']['init_style']
 when "runit"


### PR DESCRIPTION
- stringify key :nginx_configure_flags to enable passenger module to be
  compiled into nginx via recipe nginx::source
- stringify key :nginx_force_recompile to be tidy
