### PR TITLE
[COOK-2058] nginx_site definitions patched

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -29,7 +29,7 @@ define :nginx_site, :enable => true do
     execute "nxdissite #{params[:name]}" do
       command "/usr/sbin/nxdissite #{params[:name]}"
       notifies :reload, "service[nginx]"
-      only_if do ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") end
+      only_if do ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") || ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/000-#{params[:name]}") end
     end
   end
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2058

If default_site is activated once, site-enabled/000-default symlink won't disappear when you switch attribute default_site_enabled to false. This patch correct this behavious, there is maybe a better solution. Thanks.
