### PR TITLE
Added support for extra-cookbook modules

### DIFF
--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -35,3 +35,4 @@ default['nginx']['source']['modules'] = [
   "http_ssl_module",
   "http_gzip_static_module"
 ]
+default['nginx']['source']['extra_modules'] = []

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -154,6 +154,10 @@ node['nginx']['source']['modules'].each do |ngx_module|
   include_recipe "nginx::#{ngx_module}"
 end
 
+node['nginx']['source']['extra_modules'].each do |ngx_module|
+  include_recipe ngx_module
+end
+
 configure_flags = node.run_state['nginx_configure_flags']
 nginx_force_recompile = node.run_state['nginx_force_recompile']
 


### PR DESCRIPTION
Added a cookbook attribute in order to support extra-cookbook flags that may be added via an application cookbook. The attribute should describe an array that contains fully qualified recipes (i.e. "my_nginx::headers_more_module").
