### PR TITLE
[COOK-1979] - curl-dev doesn't exist in ubuntu 10.04 - 12.04

### DIFF
--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -31,7 +31,7 @@ node.default["nginx"]["passenger"]["max_requests"] = 0
 packages = value_for_platform( ["redhat", "centos", "scientific", "amazon", "oracle"] => {
                                  "default" => %w(ruby-devel curl-devel) },
                                ["ubuntu", "debian"] => {
-                                 "default" => %w(ruby-dev curl-dev) } )
+                                 "default" => %w(ruby-dev libcurl4-gnutls-dev) } )
 
 packages.each do |devpkg|
   package devpkg


### PR DESCRIPTION
Added a library that does exist, and the nginx::source and nginx::passenger recipes successfully complete with the libraries provided.
