### PR TITLE
[COOK-2168] nginx package name as an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@
 # overriding attributes by modifying a role, or the node itself.
 # default['nginx']['source']['checksum']
 default['nginx']['version'] = "1.2.3"
+default['nginx']['package_name'] = "nginx"
 default['nginx']['dir'] = "/etc/nginx"
 default['nginx']['log_dir'] = "/var/log/nginx"
 default['nginx']['binary'] = "/usr/sbin/nginx"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ when 'package'
   when 'redhat','centos','scientific','amazon','oracle'
     include_recipe 'yum::epel'
   end
-  package 'nginx'
+  package node['nginx']['package_name']
   service 'nginx' do
     supports :status => true, :restart => true, :reload => true
     action :enable


### PR DESCRIPTION
Sometimes we want to override the nginx package name. For instance if we build our own. The default remains 'nginx' so it should have no effect on existing deploys.

http://tickets.opscode.com/browse/COOK-2168
