### PR TITLE
Add support to secure_link module

### DIFF
--- a/recipes/http_secure_link_module.rb
+++ b/recipes/http_secure_link_module.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: http_secure_link_module
+#
+# Author:: Carlos Martin (<inean.es@gmail.com>)
+#
+# Copyright 2012, Carlos Martin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.run_state['nginx_configure_flags'] =
+  node.run_state['nginx_configure_flags'] | ["--with-http_secure_link_module"]


### PR DESCRIPTION
Simple recipe to add optional support to HttpSecureLink module when nginx is compiled from sources
