### PR TITLE
COOK-2280: Allow custom timing of reload after nginx_site

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -18,17 +18,17 @@
 # limitations under the License.
 #
 
-define :nginx_site, :enable => true do
+define :nginx_site, :enable => true, :timing => :delayed do
   if params[:enable]
     execute "nxensite #{params[:name]}" do
       command "/usr/sbin/nxensite #{params[:name]}"
-      notifies :reload, "service[nginx]"
+      notifies :reload, "service[nginx]", params[:timing]
       not_if do ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") end
     end
   else
     execute "nxdissite #{params[:name]}" do
       command "/usr/sbin/nxdissite #{params[:name]}"
-      notifies :reload, "service[nginx]"
+      notifies :reload, "service[nginx]", params[:timing]
       only_if do ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") end
     end
   end


### PR DESCRIPTION
Allows the reload notification to be triggered immediately in situations where that's useful. For instance where nginx is installed near the start of a chef run, and the default site needs to be disabled quickly or other sites need to be made active ASAP.

Retains identical default behavior.

Fixes: [COOK-2280](http://tickets.opscode.com/browse/COOK-2280)
