### PR TITLE
[COOK-2398] Allow nginx_site to manage the default site

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -23,13 +23,19 @@ define :nginx_site, :enable => true, :timing => :delayed do
     execute "nxensite #{params[:name]}" do
       command "/usr/sbin/nxensite #{params[:name]}"
       notifies :reload, "service[nginx]", params[:timing]
-      not_if do ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") end
+      not_if do
+        ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") ||
+          ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/000-#{params[:name]}")
+      end
     end
   else
     execute "nxdissite #{params[:name]}" do
       command "/usr/sbin/nxdissite #{params[:name]}"
       notifies :reload, "service[nginx]", params[:timing]
-      only_if do ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") end
+      only_if do
+        ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") ||
+          ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/000-#{params[:name]}")
+      end
     end
   end
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2398

The nxensite and nxdissite scripts prepend a '000' priority to the
symlink name for the default site. Adding this to the guard conditions
for the nginx_site definition lets us enable and disable the default
site properly.
