### PR TITLE
[COOK-2432] Use nginx.org package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ be controlled by an attribute, so it may not be a common "default."
 
 On RHEL family distros, the "yum" cookbook is required for "`recipe[yum::epel]`".
 
+On Ubuntu, when using Nginx.org's stable package, "`recipe[apt]`"
+is required.
+
 Platform
 --------
 
@@ -229,10 +232,13 @@ These attributes are used in the `nginx::http_echo_module` recipe.
 Recipes
 =======
 
-This cookbook provides two main recipes for installing Nginx.
+This cookbook provides three main recipes for installing Nginx.
 
 * default.rb: *Use this recipe* if you have a native package for
   Nginx.
+* nginx-org-package.rb: The developer of Nginx also maintain
+  [stable packages](http://nginx.org/en/download.html) for several
+  platforms. (Only Ubuntu support implemented presently)
 * source.rb: *Use this recipe* if you do not have a native package for
   Nginx, or if you want to install a newer version than is available,
   or if you have custom module compilation needs.

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ end
 
 depends 'ohai', '>= 1.1.4'
 
-%w{ bluepill yum }.each do |cb|
+%w{ bluepill yum apt }.each do |cb|
   recommends cb
 end
 

--- a/recipes/nginx-org-package.rb
+++ b/recipes/nginx-org-package.rb
@@ -1,0 +1,19 @@
+include_recipe 'apt'
+
+case node['platform']
+when 'ubuntu'
+  apt_repository 'nginx.org' do
+    uri 'http://nginx.org/packages/ubuntu'
+    distribution node['lsb']['codename']
+    components ['nginx']
+    key 'http://nginx.org/keys/nginx_signing.key'
+  end
+
+  include_recipe 'nginx'
+
+  file '/etc/nginx/conf.d/default.conf' do
+    action :delete
+  end
+else
+  Chef::Log.error "Nginx.org package not implmented for platform: #{node['platform']}"
+end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2432

The developer of Nginx is maintaining "Pre-Built Linux Packages for Stable" at http://nginx.org/en/download.html for RedHat, CentOS, Debian, and Ubuntu. These are often superior to what is packaged with these distributions. We should be able to use those.
