### PR TITLE
[COOK-2455] Support sendfile option (nginx.conf) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ config file.
 * `node['nginx']['disable_access_log']` - set to true to disable the
   general access log, may be useful on high traffic sites.
 * `node['nginx']['default_site_enabled']` - enable the default site
+* `node['nginx']['sendfile']` - Whether to use `sendfile`. Defaults to "on".
 * `node['nginx']['install_method']` - Whether nginx is installed from
   packages or from source.
 * `node['nginx']['types_hash_max_size']` - Used for the

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -72,6 +72,7 @@ default['nginx']['worker_rlimit_nofile'] = nil
 default['nginx']['multi_accept']       = false
 default['nginx']['event']              = nil
 default['nginx']['server_names_hash_bucket_size'] = 64
+default['nginx']['sendfile'] = 'on'
 
 default['nginx']['disable_access_log'] = false
 default['nginx']['install_method'] = 'package'

--- a/metadata.rb
+++ b/metadata.rb
@@ -108,3 +108,8 @@ attribute "nginx/disable_access_log",
 attribute "nginx/default_site_enabled",
   :display_name => "Default site enabled",
   :default => "true"
+
+attribute "nginx/sendfile",
+  :display_name => "Nginx sendfile",
+  :description => "Whether to enable sendfile",
+  :default => "on"

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -32,7 +32,7 @@ http {
   access_log	<%= node['nginx']['log_dir'] %>/access.log;
   <% end %>
 
-  sendfile on;
+  sendfile <%= node['nginx']['sendfile'] %>;
   tcp_nopush on;
   tcp_nodelay on;
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2455

Currently the sendfile option in nginx.conf.erb is hardcoded to "on". This can lead to changes in static files not being served properly when running nginx in VirtualBox. Being able to set sendfile to "off" is an easy fix for this.
