### PR TITLE
[COOK-2531] Remove non-existant attribute "description" for apt_repository

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -33,7 +33,6 @@ when "debian"
   include_recipe "apt"
 
   apt_repository "nginx" do
-    description "Nginx.org Repository"
     uri node['nginx']['upstream_repository']
     distribution node['lsb']['codename']
     components ["nginx"]


### PR DESCRIPTION
The `nginx::repo` recipe contains the following definition:

```
apt_repository "nginx" do
  description "Nginx.org Repository"
  uri node['nginx']['upstream_repository']
  ..
end
```

However, the `apt_repository` LWRP has no attribute `description`. Thus remove it.
