### PR TITLE
[COOK-2927] - http_realip_module support for real_ip_recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,13 @@ config file.
 
 *nginx::http_realip_module*
 
-From: http://wiki.nginx.org/HttpRealIpModule
+From: http://nginx.org/en/docs/http/ngx_http_realip_module.html
 
 * `node['nginx']['realip']['header']` - Header to use for the RealIp
   Module; only accepts "X-Forwarded-For" or "X-Real-IP"
 * `node['nginx']['realip']['addresses']` - Addresses to use for the
   `http_realip` configuration.
+* `node['nginx']['realip']['real_ip_recursive']` - If recursive search is enabled, the original client address that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field. Can be on "on" or "off" (default).
 
 ## source.rb
 

--- a/recipes/http_realip_module.rb
+++ b/recipes/http_realip_module.rb
@@ -24,6 +24,7 @@
 # Currently only accepts X-Forwarded-For or X-Real-IP
 node.default['nginx']['realip']['header']    = "X-Forwarded-For"
 node.default['nginx']['realip']['addresses'] = ["127.0.0.1"]
+node.default['nginx']['realip']['real_ip_recursive'] = "off"
 
 template "#{node['nginx']['dir']}/conf.d/http_realip.conf" do
   source "modules/http_realip.conf.erb"
@@ -32,7 +33,8 @@ template "#{node['nginx']['dir']}/conf.d/http_realip.conf" do
   mode 00644
   variables(
     :addresses => node['nginx']['realip']['addresses'],
-    :header => node['nginx']['realip']['header']
+    :header => node['nginx']['realip']['header'],
+    :real_ip_recursive => node['nginx']['realip']['real_ip_recursive']
   )
 
   notifies :reload, "service[nginx]"

--- a/templates/default/modules/http_realip.conf.erb
+++ b/templates/default/modules/http_realip.conf.erb
@@ -2,3 +2,4 @@
 set_real_ip_from <%= address %>;
 <% end %>
 real_ip_header <%= @header %>;
+real_ip_recursive <%= @real_ip_recursive %>;


### PR DESCRIPTION
- add support for real_ip_recursive directive in nginx::http_realip_module

http://tickets.opscode.com/browse/COOK-2927
