### PR TITLE
[COOK-3241] Fix ohai_plugin recipe when not using source

### DIFF
--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -30,7 +30,6 @@ template "#{node['ohai']['plugin_path']}/nginx.rb" do
   group "root"
   mode 00755
   variables(
-    :nginx_prefix => node['nginx']['source']['prefix'],
     :nginx_bin => node['nginx']['binary']
   )
   notifies :reload, 'ohai[reload_nginx]', :immediately

--- a/templates/default/plugins/nginx.rb.erb
+++ b/templates/default/plugins/nginx.rb.erb
@@ -44,7 +44,7 @@ nginx[:configure_arguments] = Array.new unless nginx[:configure_arguments]
 nginx[:prefix]              = nil unless nginx[:prefix]
 nginx[:conf_path]           = nil unless nginx[:conf_path]
 
-status, stdout, stderr = run_command(:no_status_check => true, :cwd => "<%= @nginx_prefix %>", :command => "<%= @nginx_bin %> -V")
+status, stdout, stderr = run_command(:no_status_check => true, :command => "<%= @nginx_bin %> -V")
 
 if status == 0
   stderr.split("\n").each do |line|


### PR DESCRIPTION
The ohai_plugin recipe is requesting the
`node['nginx']['source']['prefix']` attribute which doesn't exist unless
you're including the source recipe (and attributes). Since
`node['nginx']['binary']` is a fully qualified path including a prefix
isn't necessary.
