### PR TITLE
[COOK-3322] Ohai plugin does not work with source install method

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,12 +18,12 @@
 # limitations under the License.
 #
 
-include_recipe 'nginx::ohai_plugin'
-
 case node['nginx']['install_method']
 when 'source'
   include_recipe 'nginx::source'
+  include_recipe 'nginx::ohai_plugin'
 when 'package'
+  include_recipe 'nginx::ohai_plugin'
   case node['platform']
   when 'redhat','centos','scientific','amazon','oracle'
     if node['nginx']['repo_source'] == 'epel'


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3322

source recipe rewrite node['nginx']['binary'] 

``` ruby
node.set['nginx']['binary']          = node['nginx']['source']['sbin_path']
```

and ohai_plugin use it, 

``` ruby
  variables(
    :nginx_prefix => node['nginx']['source']['prefix'],
    :nginx_bin => node['nginx']['binary']
  )
```

``` erb
status, stdout, stderr = run_command(:no_status_check => true, :cwd => "<%= @nginx_prefix %>", :command => "<%= @nginx_bin %> -V")
```

so <code>nginx::source</code> recipe must be included before <code>nginx::ohai_plugin</code>.
