### PR TITLE
COOK-3571: nginx ohai plugin needs to be reloaded after nginx installation

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,9 @@ when 'package'
       raise ArgumentError, "Unknown value '#{node['nginx']['repo_source']}' was passed to the nginx cookbook."
     end
   end
-  package node['nginx']['package_name']
+  package node['nginx']['package_name'] do
+    notifies :reload, 'ohai[reload_nginx]', :immediately
+  end
   service 'nginx' do
     supports :status => true, :restart => true, :reload => true
     action :enable

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -102,6 +102,7 @@ bash "compile_nginx_source" do
   end
 
   notifies :restart, "service[nginx]"
+  notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 
 case node['nginx']['init_style']


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3571
