### PR TITLE
[COOK-3322] nginx::ohai_plugin fails when using source recipe (include oh...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,8 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'nginx::ohai_plugin'
-
 case node['nginx']['install_method']
 when 'source'
   include_recipe 'nginx::source'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3322

Include ohai_plugin removed from ::default.
