### PR TITLE
Using empty string repo_source as legal indicator for no repo install...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,7 @@ when 'package'
       include_recipe 'yum::epel'
     elsif node['nginx']['repo_source'] == 'nginx'
       include_recipe 'nginx::repo'
-    elsif node['nginx']['repo_source'].nil?
+    elsif node['nginx']['repo_source'].nil? || node['nginx']['repo_source'].empty?
       log "node['nginx']['repo_source'] was not set, no additional yum repositories will be installed." do
         level :debug
       end


### PR DESCRIPTION
I was unable to set repo_source to nil - doing so simply resulted in it using the default of "epel"

So I allowed it use an empty string to indicate that I don't want it to set up any repos.
