### PR TITLE
[COOK-3672] Add gzip_static option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,6 +55,7 @@ default['nginx']['group'] = node['nginx']['user']
 default['nginx']['pid'] = '/var/run/nginx.pid'
 
 default['nginx']['gzip']              = 'on'
+default['nginx']['gzip_static']       = 'off'
 default['nginx']['gzip_http_version'] = '1.0'
 default['nginx']['gzip_comp_level']   = '2'
 default['nginx']['gzip_proxied']      = 'any'

--- a/recipes/http_gzip_static_module.rb
+++ b/recipes/http_gzip_static_module.rb
@@ -19,5 +19,12 @@
 # limitations under the License.
 #
 
+template "#{node['nginx']['dir']}/conf.d/http_gzip_static.conf" do
+  source 'modules/http_gzip_static.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
 node.run_state['nginx_configure_flags'] =
   node.run_state['nginx_configure_flags'] | ['--with-http_gzip_static_module']

--- a/templates/default/modules/http_gzip_static.conf.erb
+++ b/templates/default/modules/http_gzip_static.conf.erb
@@ -1,0 +1,1 @@
+gzip_static <%= node['nginx']['gzip_static'] %>;


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3672

Nginx with on-the-fly Gzip compression does not pass the Content-Length: header, which
is used by CloudFront and other CDN's to determine whether a file has been fully received.

Modify the recipe to support the gzip_static option so that precompressed Gzip files can
be used, which doesn't cause htis problem.
