### PR TITLE
[COOK-3626] Fix hardcoded paths for helper scripts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@
 default['nginx']['version'] = "1.2.9"
 default['nginx']['package_name'] = "nginx"
 default['nginx']['dir'] = "/etc/nginx"
+default['nginx']['script_dir'] = '/usr/sbin'
 default['nginx']['log_dir'] = "/var/log/nginx"
 default['nginx']['binary'] = "/usr/sbin/nginx"
 

--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -21,7 +21,7 @@
 define :nginx_site, :enable => true, :timing => :delayed do
   if params[:enable]
     execute "nxensite #{params[:name]}" do
-      command "/usr/sbin/nxensite #{params[:name]}"
+      command "#{node['nginx']['script_dir']}/nxensite #{params[:name]}"
       notifies :reload, "service[nginx]", params[:timing]
       not_if do
         ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") ||
@@ -30,7 +30,7 @@ define :nginx_site, :enable => true, :timing => :delayed do
     end
   else
     execute "nxdissite #{params[:name]}" do
-      command "/usr/sbin/nxdissite #{params[:name]}"
+      command "#{node['nginx']['script_dir']}/nxdissite #{params[:name]}"
       notifies :reload, "service[nginx]", params[:timing]
       only_if do
         ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/#{params[:name]}") ||

--- a/recipes/commons_script.rb
+++ b/recipes/commons_script.rb
@@ -19,7 +19,7 @@
 #
 
 %w(nxensite nxdissite).each do |nxscript|
-  template "/usr/sbin/#{nxscript}" do
+  template "#{node['nginx']['script_dir']}/#{nxscript}" do
     source "#{nxscript}.erb"
     mode 00755
     owner "root"


### PR DESCRIPTION
The paths to the helper scripts nxensite and nxdissite have been hardcoded in the recipe. Since /usr/sbin is not writable on some system this is kind of a nuisance, this path makes the path for the scripts configurable.
