### PR TITLE
[COOK-3808] fixes nginx::passenger run fails because of broken installation of package dependencies

### DIFF
--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -18,8 +18,8 @@
 #
 
 packages = value_for_platform_family(
-  %w[rhel]   => { 'default' => %w[ruby-devel curl-devel] },
-  %w[debian] => { 'default' => %w[ruby-dev libcurl4-gnutls-dev] }
+  %w[rhel]   => %w[ruby-devel curl-devel],
+  %w[debian] => %w[ruby-dev libcurl4-gnutls-dev]
 )
 
 packages.each do |name|


### PR DESCRIPTION
When running nginx::passenger the arguments given to the 'package' command are broken:

```
Recipe: nginx::passenger
package[["default", ["ruby-dev", "libcurl4-gnutls-dev"]]] action install
================================================================================
Error executing action `install` on resource 'package[["default", ["ruby-dev", "libcurl4-gnutls-dev"]]]'
================================================================================
```

I have removed the "default => ..." hash from the parameters to the value_for_platform_family method.
