### PR TITLE
Choose default root folder.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ default['nginx']['dir']          = '/etc/nginx'
 default['nginx']['script_dir']   = '/usr/sbin'
 default['nginx']['log_dir']      = '/var/log/nginx'
 default['nginx']['binary']       = '/usr/sbin/nginx'
+default['nginx']['default_root'] = '/var/www/nginx-default'
 
 case node['platform_family']
 when 'debian'

--- a/templates/default/default-site.erb
+++ b/templates/default/default-site.erb
@@ -5,7 +5,7 @@ server {
   access_log  <%= node['nginx']['log_dir'] %>/localhost.access.log;
 
   location / {
-    root   /var/www/nginx-default;
+    root   <%= node['nginx']['default_root'] %>;
     index  index.html index.htm;
   }
 }


### PR DESCRIPTION
I find this useful for eg: vagrant environments. So I can change the root folder from a role configuration instead of overwriting the template entirely.
