### PR TITLE
server_names_hash_max_size option added to nginx.conf template

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Generally used attributes. Some have platform specific values. See `attributes/d
   suitable method for your OS.
 - `node['nginx']['server_tokens']` - used for config value of
   `server_tokens`.
+- `node['nginx']['server_names_hash_max_size']` - used for config
+  value of `server_names_hash_max_size`.
 - `node['nginx']['server_names_hash_bucket_size']` - used for config
   value of `server_names_hash_bucket_size`.
 - `node['nginx']['disable_access_log']` - set to true to disable the

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -84,6 +84,7 @@ default['nginx']['worker_rlimit_nofile'] = nil
 default['nginx']['multi_accept']         = false
 default['nginx']['event']                = nil
 default['nginx']['server_tokens']        = nil
+default['nginx']['server_names_hash_max_size'] = 512
 default['nginx']['server_names_hash_bucket_size'] = 64
 default['nginx']['sendfile'] = 'on'
 

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -59,6 +59,7 @@ http {
   gzip_disable     "<%= node['nginx']['gzip_disable'] %>";
   <% end %>
 
+  server_names_hash_max_size <%= node['nginx']['server_names_hash_max_size'] %>;
   server_names_hash_bucket_size <%= node['nginx']['server_names_hash_bucket_size'] %>;
   types_hash_max_size <%= node['nginx']['types_hash_max_size'] %>;
   types_hash_bucket_size <%= node['nginx']['types_hash_bucket_size'] %>;


### PR DESCRIPTION
If a server has lots of virtualhosts nginx won't start without this option tuned.
