### PR TITLE
[COOK-4237] Nginx version incorrectly parsed on Ubuntu 13

### DIFF
--- a/templates/default/plugins/nginx.rb.erb
+++ b/templates/default/plugins/nginx.rb.erb
@@ -59,7 +59,7 @@ if status == 0
 
       nginx[:prefix] = prefix
       nginx[:conf_path] = conf_path
-    when /^nginx version: nginx\/(.+)/
+    when /^nginx version: nginx\/(\d+\.\d+\.\d+)/
       nginx[:version] = $1
     end
   end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4237

When installing Nginx from default repository on Ubuntu 13 (both Ubuntu 13.04 and Ubuntu 13.10), nginx command prints the distribution name following the version number.

``` shell
$ nginx -v
nginx version: nginx/1.4.1 (Ubuntu)
```

So node[:nginx][:version] ends up with "1.4.1 (Ubuntu)".
