### PR TITLE
Add dot to ubuntu vagrant box platform names

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,8 @@ platforms:
   - name: centos-5.10
   - name: centos-6.5
   - name: fedora-19
-  - name: ubuntu-1004
-  - name: ubuntu-1204
+  - name: ubuntu-10.04
+  - name: ubuntu-12.04
 
 suites:
   - name: default


### PR DESCRIPTION
This addresses COOK-4380

https://tickets.opscode.com/browse/COOK-4380
