### PR TITLE
Allow ohai ~> 2.0 as a dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ recipe 'nginx::source', 'Installs nginx from source and sets up configuration wi
 depends 'apt',             '~> 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 1.4'
-depends 'ohai',            '~> 1.1'
+depends 'ohai',            '~> 2.0'
 depends 'runit',           '~> 1.2'
 depends 'yum',             '~> 3.0'
 depends 'yum-epel'


### PR DESCRIPTION
Seems that ohai 2.0 recently got released and the nginx cookbook dependency needed to be updated to reflect the new ohai major/minor version.
