### PR TITLE
bump ohai version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ recipe 'nginx::source', 'Installs nginx from source and sets up configuration wi
 depends 'apt',             '~> 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
-depends 'ohai',            '~> 1.1'
+depends 'ohai',            '~> 2.0'
 depends 'runit',           '~> 1.2'
 depends 'yum-epel',        '~> 0.3'
 


### PR DESCRIPTION
I have a cookbook, first in my runlist which depends ohai and doesn't fix the version.
I have a second cookbook, which depends on nginx, which depends ohai: ~> 1.1
chef 11 fails to resolve dependencies (and goes into a multi-threaded tight loop) when the two cookbooks are in the runlist.
Updating ohai dependency to 2.0 doesn't break kitchen test (although this doesn't seem to actually test any of the ohai functionality).  Please consider removing the version dependency altogether?  It is easier to fix an actual break than to discover where the depsolver in chef-server is failing and getting into a tight loop.
We can only hope that the depsolver is fixed soon.
