### PR TITLE
Allow nginx_site to work without a template argument.

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -19,10 +19,9 @@
 # limitations under the License.
 #
 
-define :nginx_site, :template => 'default-site.erb', :port => 80, :docroot => '/var/www/nginx-default', :enable => true, :timing => :delayed do
+define :nginx_site, :template => nil, :port => 80, :docroot => '/var/www/nginx-default', :enable => true, :timing => :delayed do
   if params[:enable]
-
-    if params[:template]
+    if !params[:template].nil?
       template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
         source params[:template]
         owner 'root'

--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -29,5 +29,6 @@ template 'nginx.conf' do
 end
 
 nginx_site 'default' do
+  template 'default-site.rb'
   enable node['nginx']['default_site_enabled']
 end

--- a/spec/support/matchers/nginx_site.rb
+++ b/spec/support/matchers/nginx_site.rb
@@ -1,8 +1,12 @@
+require 'rspec/core'
+require 'rspec/expectations'
+require 'rspec/mocks'
+
 # Custom ChefSpec matchers
 module ChefSpec::Matchers
   RSpec::Matchers.define :enable_nginx_site do |site|
     match do |chef_run|
-      chef_run.resources.any? do |resource|
+      chef_run.find_resources(:nginx_site) do |resource|
         resource.resource_name == :execute && resource.name =~ /.*nxensite.*#{site}/
       end
     end
@@ -10,7 +14,7 @@ module ChefSpec::Matchers
 
   RSpec::Matchers.define :disable_nginx_site do |site|
     match do |chef_run|
-      chef_run.resources.any? do |resource|
+      chef_run.find_resources(:nginx_site) do |resource|
         resource.resource_name == :execute && resource.name =~ /.*nxdissite.*#{site}/
       end
     end

--- a/spec/unit/recipes/commons_conf_spec.rb
+++ b/spec/unit/recipes/commons_conf_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'nginx::commons_conf' do
+  let(:chef_run) do
+    ChefSpec::Runner.new().converge('nginx::default', described_recipe)
+  end
+
+  it 'creates nginx.conf' do
+    expected_conf_file = "#{chef_run.node['nginx']['dir']}/nginx.conf"
+    expect(chef_run).to render_file(expected_conf_file)
+  end
+
+  it 'enables default site' do
+    expected_site_file = "#{chef_run.node['nginx']['dir']}/sites-available/default"
+    expect(chef_run).to render_file(expected_site_file)
+  end
+
+  context "default_site_enabled = false" do
+    let(:chef_run) do 
+      runner = ChefSpec::Runner.new()
+      runner.node.set['nginx']['default_site_enabled'] = false
+      runner.converge('nginx::default', described_recipe)
+    end
+
+    it 'disables default site' do
+      expected_site_file = "#{chef_run.node['nginx']['dir']}/sites-available/default"
+      expect(chef_run).not_to render_file(expected_site_file)
+    end
+  end
+end


### PR DESCRIPTION
A recent update broke backwards compatibility on the `nginx_site` LWRP wherein it basically requires the `template` argument. I've changed it so that the default is `nil` and added a test. Also fixed up the matchers to work with the version of RSpec specified in the Gemfile.
