### PR TITLE
Update passenger recipe to accept custom ruby install with rvm cookbook

### DIFF
--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -36,8 +36,8 @@ else
   node.default['nginx']['passenger']['ruby'] = '/usr/bin/ruby'
 end
 
-node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel curl-devel)
-node.default['nginx']['passenger']['packages']['debian'] = %w(ruby-dev libcurl4-gnutls-dev)
+node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel curl-devel rubygems)
+node.default['nginx']['passenger']['packages']['debian'] = %w(ruby-dev libcurl4-gnutls-dev rubygems)
 
 node.default['nginx']['passenger']['spawn_method'] = 'smart-lv2'
 node.default['nginx']['passenger']['buffer_response'] = 'on'


### PR DESCRIPTION
Hello,

I am using this [rvm cookbook](https://github.com/fnichol/chef-rvm) for my provisioning, so I added the possibility to change the ruby used when installing passenger.

I might have forgotten things to change, but this was enough for my usage (chef-solo), please let me know if this is something you'd like to integrate here.

Cheers,
Paul
