### PR TITLE
updating ohai dep to 2.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ recipe 'nginx::source', 'Installs nginx from source and sets up configuration wi
 depends 'apt',             '~> 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
-depends 'ohai',            '~> 1.1'
+depends 'ohai',            '~> 2.0'
 depends 'runit',           '~> 1.2'
 depends 'yum-epel',        '~> 0.3'
 


### PR DESCRIPTION
Ohai is at version 2.0. The nginx cookbook still lists ~> 1.1 as a dependency.

Is there a particular reason to keep the dep anchored to 1.1?

Also, knife cookbook site install nginx will download the latest version of ohai (2.0) creating a 'wedged' install until the user deletes ohai and specifies version 1.1 or edits metadata.rb in the nginx cookbook.
