### PR TITLE
Fix header-more module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ nginx Cookbook CHANGELOG
 ========================
 This file is used to list changes made in each version of the nginx cookbook.
 
+Not release
+-------------------
+- Fix header-more module referencing an old github repository
+
 
 v2.6.2 (2014-04-09)
 -------------------

--- a/recipes/headers_more_module.rb
+++ b/recipes/headers_more_module.rb
@@ -42,8 +42,8 @@ bash 'extract_headers_more' do
   user 'root'
   code <<-EOH
     tar -zxf #{tar_location} -C #{module_location}
-    mv -f #{module_location}/agentz*/* #{module_location}
-    rm -rf #{module_location}/agentz*
+    mv -f #{module_location}/*headers-more-nginx-module*/* #{module_location}
+    rm -rf #{module_location}/*headers-more-nginx-module*
   EOH
   not_if { ::File.exists?("#{module_location}/config") }
 end


### PR DESCRIPTION
It was referencing an old name in the tarball because of the header-more-module change of owner on github.

This fixes the issue
