### PR TITLE
[COOK-4644] - add support to nginx::repo for Amazon Linux (which as of 2013.09 is RHEL 6 based)

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -25,6 +25,8 @@ when 'rhel', 'fedora'
   when 'centos'
     # See http://wiki.nginx.org/Install
     default['nginx']['upstream_repository'] = "http://nginx.org/packages/centos/#{node['platform_version'].to_i}/$basearch/"
+  when 'amazon'
+    default['nginx']['upstream_repository'] = "http://nginx.org/packages/rhel/6/$basearch/"
   else
     default['nginx']['upstream_repository'] = "http://nginx.org/packages/rhel/#{node['platform_version'].to_i}/$basearch/"
   end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -25,6 +25,7 @@ if platform_family?('rhel')
     include_recipe 'yum-epel'
   elsif node['nginx']['repo_source'] == 'nginx'
     include_recipe 'nginx::repo'
+    package_install_opts = '--disablerepo=* --enablerepo=nginx'
   elsif node['nginx']['repo_source'].nil?
     log "node['nginx']['repo_source'] was not set, no additional yum repositories will be installed." do
       level :debug
@@ -37,6 +38,7 @@ elsif platform_family?('debian')
 end
 
 package node['nginx']['package_name'] do
+  options package_install_opts
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4644

Updates the attributes file to use a valid repository URL for Amazon linux, and forces the nginx repository when specified for yum
