### PR TITLE
Update dependency requirement on ohai

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ recipe 'nginx::source', 'Installs nginx from source and sets up configuration wi
 depends 'apt',             '~> 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
-depends 'ohai',            '~> 1.1'
+depends 'ohai',            '>= 1.1'
 depends 'runit',           '~> 1.2'
 depends 'yum-epel',        '~> 0.3'
 


### PR DESCRIPTION
Version 1.1 of ohai is no longer available

```
> knife cookbook site download ohai 1.1
ERROR: The object you are looking for could not be found
```
