### PR TITLE
[COOK-4703] - Default openssl version to 1.0.1h to address CVE-2014-0224

### DIFF
--- a/attributes/openssl_source.rb
+++ b/attributes/openssl_source.rb
@@ -19,5 +19,5 @@
 # limitations under the License.
 #
 
-default['nginx']['openssl_source']['version']  = '1.0.1g'
+default['nginx']['openssl_source']['version']  = '1.0.1h'
 default['nginx']['openssl_source']['url']      = "http://www.openssl.org/source/openssl-#{node['nginx']['openssl_source']['version']}.tar.gz"


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4703
