### PR TITLE
[COOK-4592] Fix path to headers more files

### DIFF
--- a/recipes/headers_more_module.rb
+++ b/recipes/headers_more_module.rb
@@ -42,8 +42,8 @@ bash 'extract_headers_more' do
   user 'root'
   code <<-EOH
     tar -zxf #{tar_location} -C #{module_location}
-    mv -f #{module_location}/agentz*/* #{module_location}
-    rm -rf #{module_location}/agentz*
+    mv -f #{module_location}/openresty-headers-more-nginx-module*/* #{module_location}
+    rm -rf #{module_location}/openresty-headers-more-nginx-module*
   EOH
   not_if { ::File.exists?("#{module_location}/config") }
 end


### PR DESCRIPTION
We might want to just add the following instead since it is just a single subfolder and to be backwards compatible but the thing is the folder name changed from `agentz` to `openresty` so to make it install some change like this one is needed.

``` sh
mv -f #{module_location}/*/* #{module_location}
```
