### PR TITLE
Only include Yum on RHEL platforms

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,10 @@ depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
 depends 'ohai',            '~> 2.0'
 depends 'runit',           '~> 1.2'
+case node["platform_family"]
+case "rhel"
 depends 'yum-epel',        '~> 0.3'
+end
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
There is no need to include the Yum cookbook on Debian-based systems, and sometimes causes dependency issues, especially in the complexity that is OpsWorks.

Error Resolving Cookbooks for Run List:
Missing Cookbooks:

Could not satisfy version constraints for: yum

Expanded Run List:

opsworks_initial_setup
ssh_host_keys
ssh_users
mysql::client
dependencies
ebs
opsworks_ganglia::client
opsworks_stack_state_sync
rabbitmq_cluster
deploy::default
test_suite
opsworks_cleanup
[2014-06-16T18:17:43+00:00] ERROR: Running exception handlers
[2014-06-16T18:17:43+00:00] ERROR: Exception handlers complete
[2014-06-16T18:17:43+00:00] FATAL: Stacktrace dumped to /var/lib/aws/opsworks/cache/chef-stacktrace.out
[2014-06-16T18:17:43+00:00] ERROR: 412 "Precondition Failed"
[2014-06-16T18:17:43+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
