### PR TITLE
Update to RuboCop ~> 0.23 to avoid build failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :lint do
   gem 'foodcritic', '~> 3.0'
-  gem 'rubocop',    '~> 0.19'
+  gem 'rubocop',    '~> 0.23'
 end
 
 group :unit do

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'kitchen'
 # Style tests. Rubocop and Foodcritic
 namespace :style do
   desc 'Run Ruby style checks'
-  Rubocop::RakeTask.new(:ruby)
+  RuboCop::RakeTask.new(:ruby)
 
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|
@@ -37,21 +37,21 @@ namespace :integration do
       instance.test(:always)
     end
   end
-  
+
   desc 'Run Test Kitchen with cloud plugins'
   task :cloud do
     run_kitchen = true
     if ENV['TRAVIS'] == 'true' && ENV['TRAVIS_PULL_REQUEST'] != 'false'
       run_kitchen = false
     end
-    
+
     if run_kitchen
       Kitchen.logger = Kitchen.default_file_logger
       @loader = Kitchen::Loader::YAML.new(project_config: './.kitchen.cloud.yml')
       config = Kitchen::Config.new( loader: @loader)
       config.instances.each do |instance|
-        instance.test(:always)      
-      end      
+        instance.test(:always)
+      end
     end
   end
 end


### PR DESCRIPTION
RuboCop made a breaking change to its name, and as a result, builds on Travis will fail until this is change. This fixes that, and allows the Rake task to run properly.
