### PR TITLE
Update Berkshelf gem to use released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :lint do
 end
 
 group :unit do
-  gem 'berkshelf', '~> 3.0.0.beta7'
+  gem 'berkshelf', '~> 3.1'
   gem 'chefspec',  '~> 3.1'
 end
 


### PR DESCRIPTION
No need to keep using beta versions when a solid release is available.
