### PR TITLE
Update mime.types with proper javascript type

### DIFF
--- a/files/default/mime.types
+++ b/files/default/mime.types
@@ -4,7 +4,7 @@ types {
     text/xml                              xml;
     image/gif                             gif;
     image/jpeg                            jpeg jpg;
-    application/x-javascript              js;
+    application/javascript                js;
     application/json                      json;
     application/atom+xml                  atom;
     application/rss+xml                   rss;


### PR DESCRIPTION
`application/x-javascript` should be `application/javascript` per the RFC and official nginx config
see: http://trac.nginx.org/nginx/changeset/ae3fd1ca62e0942a6c83a37f30df386622462c80/nginx
and: http://www.rfc-editor.org/rfc/rfc4329.txt

This also fixes default config to work with default charset_types.
