### PR TITLE
Fix SHA256 checksum for nginx 1.4.4

### DIFF
--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -34,7 +34,7 @@ default['nginx']['source']['default_configure_flags'] = %W(
 default['nginx']['configure_flags']    = []
 default['nginx']['source']['version']  = node['nginx']['version']
 default['nginx']['source']['url']      = "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
-default['nginx']['source']['checksum'] = '0510af71adac4b90484ac8caf3b8bd519a0f7126250c2799554d7a751a2db388'
+default['nginx']['source']['checksum'] = '7c989a58e5408c9593da0bebcd0e4ffc3d892d1316ba5042ddb0be5b0b4102b9'
 default['nginx']['source']['modules']  = %w(
   nginx::http_ssl_module
   nginx::http_gzip_static_module


### PR DESCRIPTION
I'm not sure what's going on here, but the SHA-256 checksum I calculate for http://nginx.org/download/nginx-1.4.4.tar.gz using `sha256sum` on Ubuntu 14.04.1 is `7c989a5`, rather than the `0510af7` in `source.rb`:

```
$ wget http://nginx.org/download/nginx-1.4.4.tar.gz
$ sha256sum ./nginx-1.4.4.tar.gz
7c989a58e5408c9593da0bebcd0e4ffc3d892d1316ba5042ddb0be5b0b4102b9  ./nginx-1.4.4.tar.gz

$ ls -l /var/chef/cache/nginx-1.4.4.tar.gz
... Jun  4  2014 /var/chef/cache/nginx-1.4.4.tar.gz
$ sha256sum /var/chef/cache/nginx-1.4.4.tar.gz 
7c989a58e5408c9593da0bebcd0e4ffc3d892d1316ba5042ddb0be5b0b4102b9  /var/chef/cache/nginx-1.4.4.tar.gz
```

Recently a chef-client run threw a fatal error that the checksum was incorrect. However I still have the cached downloaded resource from June 2014 and the file is the same, `7c989a5`. So did this only recently begin being checked, or is it some other issue on my end? How was the checksum "wrong" this whole time but only recently threw the error?
