### PR TITLE
update nginx.erb

### DIFF
--- a/templates/default/nginx.service.erb
+++ b/templates/default/nginx.service.erb
@@ -3,6 +3,8 @@ Description=The nginx HTTP and reverse proxy server
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
+Type=forking
+PIDFile=/run/nginx.pid
 ExecStartPre=<%= node['nginx']['binary'] %> -t
 ExecStart=<%= node['nginx']['binary'] %>
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
On ubuntu 16 nginx service doesn't stop/start using systemctl or service commands if Type=forking is missing.
 As per
https://www.nginx.com/resources/wiki/start/topics/examples/systemd/

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
