### PR TITLE
Ensure apt-transport-https is on Debian/Ubuntu before apt_repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the nginx cookbook.
 ## Unreleased
 
 - Add CircleCI testings
+- Ensure apt-transport-https package is installed on Debian/Ubuntu for apt_repository resource
 
 ## 9.0.0 (2018-11-13)
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -18,6 +18,8 @@ when 'suse'
 
 when 'debian'
 
+  apt_package 'apt-transport-https'
+
   apt_repository 'nginx' do
     uri          node['nginx']['upstream_repository']
     distribution node['lsb']['codename']

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -8,6 +8,10 @@ describe 'nginx::repo' do
       ).converge(described_recipe)
     end
 
+    it 'ensures apt-transport-https package is installed' do
+      expect(chef_run).to install_apt_package('apt-transport-https')
+    end
+
     it 'adds apt repository' do
       expect(chef_run).to add_apt_repository('nginx').with(
         uri: 'https://nginx.org/packages/ubuntu',
@@ -21,6 +25,10 @@ describe 'nginx::repo' do
       ChefSpec::SoloRunner.new(
         platform: 'debian', version: '8.9'
       ).converge(described_recipe)
+    end
+
+    it 'ensures apt-transport-https package is installed' do
+      expect(chef_run).to install_apt_package('apt-transport-https')
     end
 
     it 'adds apt repository' do


### PR DESCRIPTION
On some cases (particularly `kitchen converge`s using bento or dokken
images of Debian/Ubuntu,) the `nginx::repo` recipe fails because it
configures an `apt_repository` that uses an HTTPS source
(e.g. https://nginx.org/packages/debian).  Users of this cookbook will
have to add the `apt-transport-https` package before including nginx.

This change aims to remove this little pessimization by ensuring to
converge `apt_pacakge 'apt-transport-https'` on Debian/Ubuntu before
converging `apt_repository` for the upstream nginx repo.