### PR TITLE
http_realip_module: Move inline attributes out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the nginx cookbook.
 ## Unreleased
 
 - Add CircleCI testings
+- http_realip_module: Move inline attributes out so that they can be overridden in the environment.
 
 ## 9.0.0 (2018-11-13)
 

--- a/attributes/realip.rb
+++ b/attributes/realip.rb
@@ -1,0 +1,4 @@
+# Currently only accepts X-Forwarded-For or X-Real-IP
+default['nginx']['realip']['header']            = 'X-Forwarded-For'
+default['nginx']['realip']['addresses']         = ['127.0.0.1']
+default['nginx']['realip']['real_ip_recursive'] = 'off'

--- a/recipes/http_realip_module.rb
+++ b/recipes/http_realip_module.rb
@@ -1,10 +1,5 @@
 # Documentation: http://wiki.nginx.org/HttpRealIpModule
 
-# Currently only accepts X-Forwarded-For or X-Real-IP
-node.default['nginx']['realip']['header']            = 'X-Forwarded-For'
-node.default['nginx']['realip']['addresses']         = ['127.0.0.1']
-node.default['nginx']['realip']['real_ip_recursive'] = 'off'
-
 template "#{node['nginx']['dir']}/conf.d/http_realip.conf" do
   source 'modules/http_realip.conf.erb'
   notifies :reload, 'service[nginx]', :delayed


### PR DESCRIPTION
### Description

Moved inline attributes out to their own attributes file similar to other module usage. This was blocking environment overrides. 

Signed-off-by: Sean Smith <sean@seansith.org>

### Issues Resolved

Fixes #479.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
