### PR TITLE
Restore fedora support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - 'ubuntu-1604'
           - 'ubuntu-1804'
           - 'centos-7'
+          - 'fedora-31'
         suite:
           - 'distro'
           - 'epel'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file is used to list changes made in each version of the nginx cookbook.
 ## 10.0.1 (2019-08-04)
 
 - Maintenance: Add contributing.md file for cookbook health metrics
+- Feature: Add support for Fedora
 
 ## 10.0.0 (2019-08-04)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The following platforms are supported and tested with Test Kitchen:
 - Amazon Linux 2
 - CentOS 7
 - Debian 8+
-- openSuSE Leap 15
+- Fedora 30
+- openSUSE Leap 15
 - Ubuntu 16.04+
 
 Other Debian and RHEL family distributions are assumed to work.

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -38,6 +38,11 @@ platforms:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: fedora-31
+    driver:
+      image: dokken/fedora-31
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: ubuntu-16.04
     driver:
       image: dokken/ubuntu-16.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,6 +18,7 @@ platforms:
   - name: centos-7
   - name: debian-8
   - name: debian-9
+  - name: fedora-31
   - name: opensuse-leap-42
   - name: ubuntu-16.04
   - name: ubuntu-18.04
@@ -29,6 +30,9 @@ suites:
     excludes:  # these all lack distro packages
       - centos-6
       - centos-7
+  - name: repo
+    run_list:
+      - recipe[test::repo]
   - name: epel
     run_list:
       - recipe[test::epel]
@@ -43,3 +47,4 @@ suites:
       - centos-6
       - centos-7
       - amazonlinux-2
+      - fedora-30

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,7 @@ depends  'ohai', '~> 5.2'
 
 supports 'amazon'
 supports 'centos'
+supports 'fedora'
 supports 'debian'
 supports 'oracle'
 supports 'redhat'


### PR DESCRIPTION
# Description

Add Fedora support back to metadata.rb. Massaged a few things to get spec tests to pass.

## Issues Resolved

- None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
