### PR TITLE
nginx: add service resource to nginx_site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## 10.0.2 (2019-09-24)
 
-- Bug Fix: Missing service resource in `nginx_site` resource. [Issue #505](https://github.com/sous-chefs/nginx/issues/505))
+- Bug Fix: Add missing service resource in `nginx_site` resource. [Issue #505](https://github.com/sous-chefs/nginx/issues/505))
 
 ## 10.0.1 (2019-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+## 10.0.2 (2019-09-24)
+
+- Bug Fix: Missing service resource in `nginx_site` resource. [Issue #505](https://github.com/sous-chefs/nginx/issues/505))
+
 ## 10.0.1 (2019-08-04)
 
 - Maintenance: Add contributing.md file for cookbook health metrics

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ chef_version     '>= 14'
 license          'Apache-2.0'
 description      'Installs and configures nginx'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '10.0.1'
+version          '10.0.2'
 
 depends  'ohai', '~> 5.2'
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -32,7 +32,7 @@ action :enable do
 
   service 'nginx' do
     supports status: true, restart: true, reload: true
-    action   [:start, :enable]
+    action   :nothing
   end
 end
 
@@ -55,6 +55,6 @@ action :disable do
 
   service 'nginx' do
     supports status: true, restart: true, reload: true
-    action   [:start, :enable]
+    action   :nothing
   end
 end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -29,6 +29,11 @@ action :enable do
     not_if   { site_enabled?(new_resource.site_name) }
     only_if  { site_available?(new_resource.site_name) }
   end
+
+  service 'nginx' do
+    supports status: true, restart: true, reload: true
+    action   [:start, :enable]
+  end
 end
 
 action :disable do
@@ -46,5 +51,10 @@ action :disable do
       user 'root'
       notifies :reload, 'service[nginx]'
     end
+  end
+
+  service 'nginx' do
+    supports status: true, restart: true, reload: true
+    action   [:start, :enable]
   end
 end

--- a/spec/unit/resources/site_spec.rb
+++ b/spec/unit/resources/site_spec.rb
@@ -12,7 +12,6 @@ describe 'nginx_site' do
   shared_examples_for 'enable default site' do
     it { is_expected.to run_execute('nxensite default') }
     it { expect(chef_run.execute('nxensite default')).to notify('service[nginx]').to(:reload).delayed }
-    it { is_expected.to reload_service('nginx') }
   end
 
   context 'with default properties' do
@@ -53,6 +52,5 @@ describe 'nginx_site' do
 
     it { is_expected.to run_execute('nxdissite default') }
     it { expect(chef_run.execute('nxdissite default')).to notify('service[nginx]').to(:reload).delayed }
-    it { is_expected.to reload_service('nginx') }
   end
 end

--- a/spec/unit/resources/site_spec.rb
+++ b/spec/unit/resources/site_spec.rb
@@ -12,8 +12,7 @@ describe 'nginx_site' do
   shared_examples_for 'enable default site' do
     it { is_expected.to run_execute('nxensite default') }
     it { expect(chef_run.execute('nxensite default')).to notify('service[nginx]').to(:reload).delayed }
-    it { is_expected.to enable_service('nginx') }
-    it { is_expected.to start_service('nginx') }
+    it { is_expected.to reload_service('nginx') }
   end
 
   context 'with default properties' do
@@ -54,7 +53,6 @@ describe 'nginx_site' do
 
     it { is_expected.to run_execute('nxdissite default') }
     it { expect(chef_run.execute('nxdissite default')).to notify('service[nginx]').to(:reload).delayed }
-    it { is_expected.to enable_service('nginx') }
-    it { is_expected.to start_service('nginx') }
+    it { is_expected.to reload_service('nginx') }
   end
 end

--- a/spec/unit/resources/site_spec.rb
+++ b/spec/unit/resources/site_spec.rb
@@ -12,6 +12,8 @@ describe 'nginx_site' do
   shared_examples_for 'enable default site' do
     it { is_expected.to run_execute('nxensite default') }
     it { expect(chef_run.execute('nxensite default')).to notify('service[nginx]').to(:reload).delayed }
+    it { is_expected.to reload_service('nginx') }
+    it { is_expected.to restart_service('nginx') }
   end
 
   context 'with default properties' do
@@ -52,5 +54,7 @@ describe 'nginx_site' do
 
     it { is_expected.to run_execute('nxdissite default') }
     it { expect(chef_run.execute('nxdissite default')).to notify('service[nginx]').to(:reload).delayed }
+    it { is_expected.to reload_service('nginx') }
+    it { is_expected.to restart_service('nginx') }
   end
 end

--- a/spec/unit/resources/site_spec.rb
+++ b/spec/unit/resources/site_spec.rb
@@ -12,8 +12,8 @@ describe 'nginx_site' do
   shared_examples_for 'enable default site' do
     it { is_expected.to run_execute('nxensite default') }
     it { expect(chef_run.execute('nxensite default')).to notify('service[nginx]').to(:reload).delayed }
-    it { is_expected.to reload_service('nginx') }
-    it { is_expected.to restart_service('nginx') }
+    it { is_expected.to enable_service('nginx') }
+    it { is_expected.to start_service('nginx') }
   end
 
   context 'with default properties' do
@@ -54,7 +54,7 @@ describe 'nginx_site' do
 
     it { is_expected.to run_execute('nxdissite default') }
     it { expect(chef_run.execute('nxdissite default')).to notify('service[nginx]').to(:reload).delayed }
-    it { is_expected.to reload_service('nginx') }
-    it { is_expected.to restart_service('nginx') }
+    it { is_expected.to enable_service('nginx') }
+    it { is_expected.to start_service('nginx') }
   end
 end


### PR DESCRIPTION
# Description

This adds the service resource for nginx so `nginx_site` will work.

## Issues Resolved

https://github.com/sous-chefs/nginx/issues/505

## Check List

- [ will have to let your CI run ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ unnecessary ] New functionality has been documented in the README if applicable.
