### PR TITLE
nginx: add service resource to nginx_site resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ lint_and_unit: &lint_and_unit
 version: 2.1
 
 orbs:
-  kitchen: sous-chefs/kitchen@2.0.2
+  kitchen: sous-chefs/kitchen@2
 
 workflows:
   kitchen:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+## 10.0.2 (2019-09-24)
+
+- Bug Fix: Add missing service resource in `nginx_site` resource. [Issue #505](https://github.com/sous-chefs/nginx/issues/505))
+
 ## 10.0.1 (2019-08-04)
 
 - Maintenance: Add contributing.md file for cookbook health metrics

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,7 @@ maintainer_email 'help@sous-chefs.org'
 chef_version     '>= 14'
 license          'Apache-2.0'
 description      'Installs and configures nginx'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '10.0.1'
+version          '10.0.2'
 
 depends  'ohai', '~> 5.2'
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -29,6 +29,11 @@ action :enable do
     not_if   { site_enabled?(new_resource.site_name) }
     only_if  { site_available?(new_resource.site_name) }
   end
+
+  service 'nginx' do
+    supports status: true, restart: true, reload: true
+    action   :nothing
+  end
 end
 
 action :disable do
@@ -46,5 +51,10 @@ action :disable do
       user 'root'
       notifies :reload, 'service[nginx]'
     end
+  end
+
+  service 'nginx' do
+    supports status: true, restart: true, reload: true
+    action   :nothing
   end
 end

--- a/spec/support/install.rb
+++ b/spec/support/install.rb
@@ -17,7 +17,16 @@ def repo_signing_key
   'https://nginx.org/keys/nginx_signing.key'
 end
 
-def platform_distribution
+def platform_distribution_nginx
+  case chefspec_platform
+  when 'debian'
+    'buster'
+  when 'ubuntu'
+    'bionic'
+  end
+end
+
+def platform_distribution_passenger
   case chefspec_platform
   when 'debian'
     'stretch'

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -181,13 +181,13 @@ RSpec.describe Nginx::Cookbook::Helpers do
         context 'with version 8' do
           let(:platform_version) { '8' }
 
-          it { expect(subject.passenger_packages).to eq ['ruby-dev', 'libcurl4-gnutls-dev', 'passenger'] }
+          it { expect(subject.passenger_packages).to eq %w(ruby-dev libcurl4-gnutls-dev passenger) }
         end
 
         context 'with version 9' do
           let(:platform_version) { '9' }
 
-          it { expect(subject.passenger_packages).to eq ['ruby-dev', 'libcurl4-gnutls-dev', 'libnginx-mod-http-passenger'] }
+          it { expect(subject.passenger_packages).to eq %w(ruby-dev libcurl4-gnutls-dev libnginx-mod-http-passenger) }
         end
       end
 
@@ -197,13 +197,13 @@ RSpec.describe Nginx::Cookbook::Helpers do
         context 'with version 16.04' do
           let(:platform_version) { '16.04' }
 
-          it { expect(subject.passenger_packages).to eq ['ruby-dev', 'libcurl4-gnutls-dev', 'passenger'] }
+          it { expect(subject.passenger_packages).to eq %w(ruby-dev libcurl4-gnutls-dev passenger) }
         end
 
         context 'with version 18.04' do
           let(:platform_version) { '18.04' }
 
-          it { expect(subject.passenger_packages).to eq ['ruby-dev', 'libcurl4-gnutls-dev', 'libnginx-mod-http-passenger'] }
+          it { expect(subject.passenger_packages).to eq %w(ruby-dev libcurl4-gnutls-dev libnginx-mod-http-passenger) }
         end
       end
     end

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -137,7 +137,7 @@ describe 'nginx_install' do
         it do
           is_expected.to add_apt_repository('nginx')
             .with_uri(repo_url)
-            .with_distribution(platform_distribution)
+            .with_distribution(platform_distribution_nginx)
             .with_components(%w(nginx))
             .with_deb_src(true)
             .with_key([repo_signing_key])
@@ -252,7 +252,7 @@ describe 'nginx_install' do
         it do
           is_expected.to add_apt_repository('phusionpassenger')
             .with_uri('https://oss-binaries.phusionpassenger.com/apt/passenger')
-            .with_distribution(platform_distribution)
+            .with_distribution(platform_distribution_passenger)
             .with_components(%w(main))
             .with_deb_src(true)
             .with_keyserver('keyserver.ubuntu.com')


### PR DESCRIPTION
# Description

This adds the service resource for nginx so `nginx_site` will work.

## Issues Resolved

https://github.com/sous-chefs/nginx/issues/505

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing. # this is not new functionality
- [ ] New functionality has been documented in the README if applicable. # this is not new functionality
