### PR TITLE
Cookstyle fixes for the apt_repository setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the nginx cookbook.
 ## Unreleased
 
 - Install packages we need for https passenger repos before we set them up
+- Remove redundant apt_repository distribution logic
 
 ## 10.0.2 (2019-09-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Install packages we need for https passenger repos before we set them up
+
 ## 10.0.2 (2019-09-24)
 
 - Bug Fix: Add missing service resource in `nginx_site` resource. [Issue #505](https://github.com/sous-chefs/nginx/issues/505))

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -182,7 +182,6 @@ action :install do
     when 'debian'
       apt_repository 'nginx' do
         uri          repo_url
-        distribution node['lsb']['codename']
         components   %w(nginx)
         deb_src      true
         key          repo_signing_key
@@ -219,7 +218,6 @@ action :install do
 
       apt_repository 'phusionpassenger' do
         uri 'https://oss-binaries.phusionpassenger.com/apt/passenger'
-        distribution node['lsb']['codename']
         components %w(main)
         deb_src true
         keyserver 'keyserver.ubuntu.com'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -213,6 +213,10 @@ action :install do
     end
   when 'passenger'
     if platform_family?('debian')
+      apt_update 'update'
+
+      package %w(apt-transport-https ca-certificates)
+
       apt_repository 'phusionpassenger' do
         uri 'https://oss-binaries.phusionpassenger.com/apt/passenger'
         distribution node['lsb']['codename']
@@ -221,9 +225,6 @@ action :install do
         keyserver 'keyserver.ubuntu.com'
         key '561F9B9CAC40B2F7'
       end
-
-      package %w(apt-transport-https ca-certificates)
-      apt_update 'update'
     else
       log 'nginx_install `source` property set to passenger, but not running on a Debian based platform so skipping passenger setup' do
         level :warn


### PR DESCRIPTION
Make sure we install the packages we need for the passenger repo before we set it up so it doesn't fail. Also, remove some default values that we don't need to pass.