### PR TITLE
Issue 538 resource logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the nginx cookbook.
 
+## Unpublished
+
+- Change resource logging to use Chef::Log instead of the log resource. Resource update
+ status reporting may change. The log resource always implies the surrounding resource
+ was updated.
+
 ## 10.1.0
 
 - Log distro installation only on log level info

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -170,7 +170,7 @@ action :install do
 
   case new_resource.source
   when 'distro'
-    Chef::Log.debug 'Using distro provided packages.'
+    Chef::Log.info 'Using distro provided packages.'
   when 'repo'
     case node['platform_family']
     when 'amazon', 'fedora', 'rhel'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -170,7 +170,7 @@ action :install do
 
   case new_resource.source
   when 'distro'
-     Chef::Log.debug 'Using distro provided packages.'
+    Chef::Log.debug 'Using distro provided packages.'
   when 'repo'
     case node['platform_family']
     when 'amazon', 'fedora', 'rhel'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -170,9 +170,7 @@ action :install do
 
   case new_resource.source
   when 'distro'
-    log 'Using distro provided packages.' do
-      level :info
-    end
+     Chef::Log.debug 'Using distro provided packages.'
   when 'repo'
     case node['platform_family']
     when 'amazon', 'fedora', 'rhel'
@@ -195,9 +193,7 @@ action :install do
         gpgkey      repo_signing_key
       end
     else
-      log "nginx.org does not maintain packages for platform #{node['platform']}. Cannot setup the repo!" do
-        level :warn
-      end
+      Chef::Log.warn "nginx.org does not maintain packages for platform #{node['platform']}. Cannot setup the repo!"
     end
 
     package_install_opts = '--disablerepo=* --enablerepo=nginx' if platform_family?('amazon', 'rhel')
@@ -208,9 +204,7 @@ action :install do
     when 'rhel'
       package 'epel-release'
     else
-      log 'nginx_install `source` property set to epel, but not running on a RHEL platform so skipping epel setup' do
-        level :warn
-      end
+      Chef::Log.warn 'nginx_install `source` property set to epel, but not running on a RHEL platform so skipping epel setup'
     end
   when 'passenger'
     if platform_family?('debian')
@@ -226,9 +220,7 @@ action :install do
         key '561F9B9CAC40B2F7'
       end
     else
-      log 'nginx_install `source` property set to passenger, but not running on a Debian based platform so skipping passenger setup' do
-        level :warn
-      end
+      Chef::Log.warn 'nginx_install `source` property set to passenger, but not running on a Debian based platform so skipping passenger setup'
     end
   end
 


### PR DESCRIPTION
# Description

Use Chef:Log instead of the log resource. I think the OP objected to the log resource saying it was updated and causing nginx to report as updated.

## Issues Resolved

#538

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
