### PR TITLE
allow using `override_package_name` to specify your own package name

### DIFF
--- a/documentation/resources/install.md
+++ b/documentation/resources/install.md
@@ -38,6 +38,7 @@ nginx_install 'default' do
   passenger_disable_anonymous_telemetry String
   passenger_anonymous_telemetry_proxy   String
   passenger_nodejs                      String
+  override_package_name                 String
 end
 ```
 
@@ -247,6 +248,16 @@ Whether or not to install rake.
 | -------------- | ------------- |
 | Type           | [true, false] |
 | Default        | `true`        |
+| Allowed Values | true, false   |
+
+### `override_package_name`
+
+Sets a manual override on the package name used. For example you might want `nginx-full` rather than `nginx-extras` or `nginx`.
+
+| property       | value         |
+| -------------- | ------------- |
+| Type           | String        |
+| Default        | `nil`         |
 | Allowed Values | true, false   |
 
 ### `passenger_root`

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,6 +29,12 @@ suites:
       - recipe[test::test_site]
     excludes:  # these all lack distro packages
       - centos-7
+  - name: nginx-full
+    run_list:
+      - recipe[test::distro]
+      - recipe[test::test_site]
+    includes: # this may be platform specific
+      - ubuntu-18.04
   - name: repo
     run_list:
       - recipe[test::repo]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -151,6 +151,9 @@ property :passenger_anonymous_telemetry_proxy, String,
 property :passenger_nodejs, String,
          description: 'Passenger nodejs.'
 
+property :override_package_name, String,
+         description: 'forcefully specify a package name such as nginx-extras, nginx-full, etc'
+
 action :install do
   if ohai_plugin_enabled?
     ohai 'reload_nginx' do
@@ -364,7 +367,9 @@ action_class do
   end
 
   def nginx_package
-    if source?('passenger') && !(debian_9? || ubuntu_18?)
+    if !new_resource.nil?
+      new_resource.override_package_name
+    elsif source?('passenger') && !(debian_9? || ubuntu_18?)
       'nginx-extras'
     else
       'nginx'

--- a/test/cookbooks/test/recipes/distro_nginx-full.rb
+++ b/test/cookbooks/test/recipes/distro_nginx-full.rb
@@ -1,0 +1,5 @@
+apt_update 'update' if platform_family?('debian')
+
+nginx_install 'distro' do
+  override_package_name 'nginx-full'
+end

--- a/test/integration/distro-nginx-full/controls/distro_spec.rb
+++ b/test/integration/distro-nginx-full/controls/distro_spec.rb
@@ -1,0 +1,1 @@
+include_controls 'install'

--- a/test/integration/distro-nginx-full/inspec.yml
+++ b/test/integration/distro-nginx-full/inspec.yml
@@ -1,0 +1,11 @@
+---
+name: distro
+title: Integration tests for nginx_install
+summary: This InSpec profile contains integration tests for nginx cookbook
+version: 0.1.0
+supports:
+  - os-family: linux
+
+depends:
+  - name: install
+    path: test/integration/install


### PR DESCRIPTION
# Description

When we moved from attribute based to resource based installation we lost the ability to specify the package name to install. To keep the changes to a minimal we will introduce a new optional property that can override the existing behavior.

This is helpful if you would like to specify `ngix-full` rather than say `nginx` or `nginx-extras`


## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
