### PR TITLE
CentOS 8 dnf fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - 'amazonlinux'
           - 'amazonlinux-2'
           - 'centos-7'
+          - 'centos-8'
           - 'debian-8'
           - 'debian-9'
           - 'fedora-31'
@@ -58,6 +59,8 @@ jobs:
           - os: 'opensuse-leap-15' # broken, see https://github.com/chef/chef/issues/9947
             suite: 'repo'
           - os: 'centos-7'
+            suite: 'distro'
+          - os: 'centos-8'
             suite: 'distro'
           - os: 'amazonlinux'
             suite: 'epel'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
             suite: 'passenger'
           - os: 'centos-7'
             suite: 'passenger'
+          - os: 'centos-8'
+            suite: 'passenger'
           - os: 'amazonlinux'
             suite: 'passenger'
           - os: 'amazonlinux-2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the nginx cookbook.
 
+## Unreleased
+
+- Add centos 8 support to cookbook
+- Disable nginx dnf module when installing from repo
+- Added 'provides' to the resources
+
 ## 10.1.1 (2020-07-27)
 
 - Change resource logging to use Chef::Log instead of the log resource. Resource update

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -38,6 +38,11 @@ platforms:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: centos-8
+    driver:
+      image: dokken/centos-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: fedora-31
     driver:
       image: dokken/fedora-31

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -38,6 +38,7 @@ suites:
       - recipe[test::test_site]
     includes:
       - centos-7
+      - centos-8
   - name: passenger
     run_list:
       - recipe[test::passenger]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -44,5 +44,6 @@ suites:
     excludes:  # passenger distro install is not compatible with these
       - opensuse-leap-15
       - centos-7
+      - centos-8
       - amazonlinux-2
-      - fedora-30
+      - fedora-31

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,6 +15,7 @@ platforms:
       box: mvbcoding/awslinux
   - name: amazonlinux-2
   - name: centos-7
+  - name: centos-8
   - name: debian-8
   - name: debian-9
   - name: fedora-31

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,3 +1,5 @@
+provides :nginx_config
+
 property :conf_cookbook, String,
          description: 'Which cookbook to use for the conf template.',
          default: 'nginx'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -172,12 +172,25 @@ action :install do
   when 'distro'
     Chef::Log.info 'Using distro provided packages.'
   when 'repo'
+    puts 'AAAAAAAAAAAAAAA'
     case node['platform_family']
     when 'amazon', 'fedora', 'rhel'
+      uses_dnf = if platform_family?('fedora')
+                   node['platform_version'].to_i > 22
+                 elsif platform_family?('rhel')
+                   node['platform_version'].to_i > 7
+                 else
+                   false
+                 end
       yum_repository 'nginx' do
         description  'Nginx.org Repository'
         baseurl      repo_url
         gpgkey       repo_signing_key
+        notifies :run, 'execute[disable-nginx-module]' if uses_dnf
+      end
+      execute 'disable-nginx-module' do
+        command 'dnf -y module disable nginx'
+        action :nothing
       end
     when 'debian'
       apt_repository 'nginx' do

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,3 +1,5 @@
+provides :nginx_install
+
 property :ohai_plugin_enabled, [true, false],
          description: 'Whether or not ohai_plugin is enabled.',
          equal_to: [true, false],
@@ -179,8 +181,7 @@ action :install do
         baseurl      repo_url
         gpgkey       repo_signing_key
       end
-      execute 'disable-nginx-module' do
-        command 'dnf -y module disable nginx'
+      execute 'dnf -qy module disable nginx' do
         only_if { node['platform_version'].to_i >= 8 && platform_family?('rhel') || platform_family?('fedora') }
         not_if 'dnf module list nginx | grep -q "^nginx.*\[x\]"'
       end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -1,3 +1,5 @@
+provides :nginx_site
+
 property :site_name, String,
          description: 'Which site to enable or disable.',
          name_property: true

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -171,14 +171,14 @@ describe 'nginx_install' do
         include_examples 'common scripts are created'
         include_examples 'common conf is created'
 
-        it { is_expected.to run_execute('disable-nginx-module') }
+        it { is_expected.to run_execute('dnf -qy module disable nginx') }
 
         context 'with nginx disabled' do
           before do
             stub_command('dnf module list nginx | grep -q "^nginx.*\\[x\\]"').and_return(true)
           end
 
-          it { is_expected.to_not run_execute('disable-nginx-module') }
+          it { is_expected.to_not run_execute('dnf -qy module disable nginx') }
         end
       end
 

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe 'nginx_install' do
   step_into :nginx_install
 
+  before do
+    stub_command('dnf module list nginx | grep -q "^nginx.*\\[x\\]"').and_return(false)
+  end
+
   context 'with default properties' do
     shared_examples_for 'ohai is enabled' do
       it { is_expected.to nothing_ohai('reload_nginx').with_plugin('nginx') }
@@ -166,6 +170,16 @@ describe 'nginx_install' do
         include_examples 'delete conf.d files'
         include_examples 'common scripts are created'
         include_examples 'common conf is created'
+
+        it { is_expected.to run_execute('disable-nginx-module') }
+
+        context 'with nginx disabled' do
+          before do
+            stub_command('dnf module list nginx | grep -q "^nginx.*\\[x\\]"').and_return(true)
+          end
+
+          it { is_expected.to_not run_execute('disable-nginx-module') }
+        end
       end
 
       context 'with debian platform' do


### PR DESCRIPTION
# Description

This adds dnf compatibility to the cookbook by disabling the module .

## Issues Resolved

The nginx module is enabled in dnf by default, and it will block us from installing the intended packages.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
