### PR TITLE
Add nginx namespace for `site_available?` and `site_enabled?` helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the nginx cookbook.
 
+## Unreleased
+
+- Add nginx namespace for `site_available?` and `site_enabled?` helper methods
+
 ## 10.3.1 (2020-09-16)
 
 - resolved cookstyle error: libraries/helpers.rb:108:1 refactor: `ChefCorrectness/IncorrectLibraryInjection`

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -63,11 +63,11 @@ module Nginx
         '/var/www/nginx-default'
       end
 
-      def site_enabled?(site_name)
+      def nginx_site_enabled?(site_name)
         ::File.symlink?("#{nginx_dir}/sites-enabled/#{site_name}") || ::File.symlink?("#{nginx_dir}/sites-enabled/000-#{site_name}")
       end
 
-      def site_available?(site_name)
+      def nginx_site_available?(site_name)
         ::File.exist?("#{nginx_dir}/sites-available/#{site_name}")
       end
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -28,8 +28,8 @@ action :enable do
   execute "nxensite #{new_resource.site_name}" do
     command  ::File.join(nginx_script_dir, "/nxensite #{new_resource.site_name}")
     notifies :reload, 'service[nginx]', :delayed
-    not_if   { site_enabled?(new_resource.site_name) }
-    only_if  { site_available?(new_resource.site_name) }
+    not_if   { nginx_site_enabled?(new_resource.site_name) }
+    only_if  { nginx_site_available?(new_resource.site_name) }
   end
 
   service 'nginx' do
@@ -42,7 +42,7 @@ action :disable do
   execute "nxdissite #{new_resource.site_name}" do
     command  ::File.join(nginx_script_dir, "/nxdissite #{new_resource.site_name}")
     notifies :reload, 'service[nginx]', :delayed
-    only_if  { site_enabled?(new_resource.site_name) }
+    only_if  { nginx_site_enabled?(new_resource.site_name) }
   end
 
   # The nginx.org packages store the default site at /etc/nginx/conf.d/default.conf and our

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -147,21 +147,21 @@ RSpec.describe Nginx::Cookbook::Helpers do
     it { expect(subject.default_root).to eq '/var/www/nginx-default' }
   end
 
-  describe '#site_enabled?' do
+  describe '#nginx_site_enabled?' do
     it do
       allow(File).to receive(:symlink?).and_call_original
       allow(File).to receive(:symlink?).with('/etc/nginx/sites-enabled/000-default').and_return(true)
 
-      expect(subject.site_enabled?('default')).to eq true
+      expect(subject.nginx_site_enabled?('default')).to eq true
     end
   end
 
-  describe '#site_available?' do
+  describe '#nginx_site_available?' do
     it do
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/etc/nginx/sites-available/default').and_return(true)
 
-      expect(subject.site_available?('default')).to eq true
+      expect(subject.nginx_site_available?('default')).to eq true
     end
   end
 


### PR DESCRIPTION
These two methods are conflicting with the apache2 cookbook and need to be named
spaced. Rename them to have `nginx_` prefixed.

These methods are only used internally so it shouldn't be a breaking change.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
