### PR TITLE
Add guard and log on service actions for invalid configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           - 'epel'
           - 'passenger'
           - 'nginx-full'
+          - 'invalid-conf'
         exclude:
           - os: 'opensuse-leap-15' # broken, see https://github.com/chef/chef/issues/9947
             suite: 'repo'
@@ -112,6 +113,27 @@ jobs:
             suite: 'nginx-full'
           - os: 'ubuntu-1604'
             suite: 'nginx-full'
+          # invalid-conf is only tested on ubuntu-18.04
+          - os: 'amazonlinux'
+            suite: 'invalid-conf'
+          - os: 'amazonlinux-2'
+            suite: 'invalid-conf'
+          - os: 'centos-7'
+            suite: 'invalid-conf'
+          - os: 'centos-8'
+            suite: 'invalid-conf'
+          - os: 'amazonlinux'
+            suite: 'invalid-conf'
+          - os: 'debian-8'
+            suite: 'invalid-conf'
+          - os: 'debian-9'
+            suite: 'invalid-conf'
+          - os: 'fedora-31'
+            suite: 'invalid-conf'
+          - os: 'opensuse-leap-15'
+            suite: 'invalid-conf'
+          - os: 'ubuntu-1604'
+            suite: 'invalid-conf'
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,27 +113,6 @@ jobs:
             suite: 'nginx-full'
           - os: 'ubuntu-1604'
             suite: 'nginx-full'
-          # invalid-conf is only tested on ubuntu-18.04
-          - os: 'amazonlinux'
-            suite: 'invalid-conf'
-          - os: 'amazonlinux-2'
-            suite: 'invalid-conf'
-          - os: 'centos-7'
-            suite: 'invalid-conf'
-          - os: 'centos-8'
-            suite: 'invalid-conf'
-          - os: 'amazonlinux'
-            suite: 'invalid-conf'
-          - os: 'debian-8'
-            suite: 'invalid-conf'
-          - os: 'debian-9'
-            suite: 'invalid-conf'
-          - os: 'fedora-31'
-            suite: 'invalid-conf'
-          - os: 'opensuse-leap-15'
-            suite: 'invalid-conf'
-          - os: 'ubuntu-1604'
-            suite: 'invalid-conf'
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the nginx cookbook.
 
+## Unreleased
+
+- Added a guard and log message to prevent starting/restarting/reloading the service when the config is invalid (#559)
+
 ## 10.4.0 (2020-10-26)
 
 - Allow list of template source for site resource (template property)

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -61,5 +61,3 @@ suites:
   - name: invalid-conf
     run_list:
       - recipe[test::invalid-conf]
-    includes:  # testing invalid config logic works, no need to run on all platforms
-      - ubuntu-18.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -58,3 +58,8 @@ suites:
       - centos-8
       - amazonlinux-2
       - fedora-31
+  - name: invalid-conf
+    run_list:
+      - recipe[test::invalid-conf]
+    includes:  # testing invalid config logic works, no need to run on all platforms
+      - ubuntu-18.04

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -357,13 +357,12 @@ action :install do
     supports status: true, restart: true, reload: true
     action   [:start, :enable]
     only_if "#{nginx_binary} -t"
-    notifies :write, 'log[nginx config invalid]', :delayed
   end
 
-  log 'nginx config invalid' do
+  log 'Validate nginx config' do
+    message 'nginx config is invalid'
     level :error
     not_if "#{nginx_binary} -t"
-    action :nothing
   end
 end
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -356,6 +356,14 @@ action :install do
   service 'nginx' do
     supports status: true, restart: true, reload: true
     action   [:start, :enable]
+    only_if "#{nginx_binary} -t"
+    notifies :write, 'log[nginx config invalid]', :delayed
+  end
+
+  log 'nginx config invalid' do
+    level :error
+    not_if "#{nginx_binary} -t"
+    action :nothing
   end
 end
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -35,6 +35,14 @@ action :enable do
   service 'nginx' do
     supports status: true, restart: true, reload: true
     action   :nothing
+    only_if "#{nginx_binary} -t"
+    notifies :write, 'log[nginx config invalid]', :delayed
+  end
+
+  log 'nginx config invalid' do
+    level :error
+    not_if "#{nginx_binary} -t"
+    action :nothing
   end
 end
 
@@ -58,5 +66,13 @@ action :disable do
   service 'nginx' do
     supports status: true, restart: true, reload: true
     action   :nothing
+    only_if "#{nginx_binary} -t"
+    notifies :write, 'log[nginx config invalid]', :delayed
+  end
+
+  log 'nginx config invalid' do
+    level :error
+    not_if "#{nginx_binary} -t"
+    action :nothing
   end
 end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -36,13 +36,12 @@ action :enable do
     supports status: true, restart: true, reload: true
     action   :nothing
     only_if "#{nginx_binary} -t"
-    notifies :write, 'log[nginx config invalid]', :delayed
   end
 
-  log 'nginx config invalid' do
+  log 'Validate nginx config' do
+    message 'nginx config is invalid'
     level :error
     not_if "#{nginx_binary} -t"
-    action :nothing
   end
 end
 
@@ -67,12 +66,11 @@ action :disable do
     supports status: true, restart: true, reload: true
     action   :nothing
     only_if "#{nginx_binary} -t"
-    notifies :write, 'log[nginx config invalid]', :delayed
   end
 
-  log 'nginx config invalid' do
+  log 'Validate nginx config' do
+    message 'nginx config is invalid'
     level :error
     not_if "#{nginx_binary} -t"
-    action :nothing
   end
 end

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -4,6 +4,10 @@ describe 'nginx_config' do
   step_into :nginx_config, :nginx_install
   platform  'ubuntu'
 
+  before do
+    stub_command('/usr/sbin/nginx -t').and_return(true)
+  end
+
   context 'with default properties' do
     recipe do
       nginx_install 'distro'

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -5,6 +5,7 @@ describe 'nginx_install' do
 
   before do
     stub_command('dnf module list nginx | grep -q "^nginx.*\\[x\\]"').and_return(false)
+    stub_command('/usr/sbin/nginx -t').and_return(true)
   end
 
   context 'with default properties' do

--- a/spec/unit/resources/site_spec.rb
+++ b/spec/unit/resources/site_spec.rb
@@ -5,6 +5,7 @@ describe 'nginx_site' do
   platform  'ubuntu'
 
   before do
+    stub_command('/usr/sbin/nginx -t').and_return(true)
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with('/etc/nginx/sites-available/default').and_return(true)
   end

--- a/test/cookbooks/test/recipes/invalid-conf.rb
+++ b/test/cookbooks/test/recipes/invalid-conf.rb
@@ -1,0 +1,9 @@
+directory '/etc/nginx/sites-enabled/' do
+  recursive true
+end
+
+file '/etc/nginx/sites-enabled/invalid' do
+  content 'Invalid NGINX Config. Fails Validation'
+end
+
+include_recipe '::repo'


### PR DESCRIPTION
- Added a guard and log message to prevent starting/restarting/reloading the service when the config is invalid (fixes #559)
