### PR TITLE
Allow multiple install packages for override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the nginx cookbook.
 
+## Unreleased
+
+- Allow multiple packages to be specified for install package name override.
+
 ## 10.5.0 (2020-10-28)
 
 - Added a guard and log message to prevent starting/restarting/reloading the service when the config is invalid (#559)

--- a/documentation/resources/install.md
+++ b/documentation/resources/install.md
@@ -38,7 +38,7 @@ nginx_install 'default' do
   passenger_disable_anonymous_telemetry String
   passenger_anonymous_telemetry_proxy   String
   passenger_nodejs                      String
-  override_package_name                 String
+  override_package_name                 [String, Array]
 end
 ```
 
@@ -254,11 +254,11 @@ Whether or not to install rake.
 
 Sets a manual override on the package name used. For example you might want `nginx-full` rather than `nginx-extras` or `nginx`.
 
-| property       | value         |
-| -------------- | ------------- |
-| Type           | String        |
-| Default        | `nil`         |
-| Allowed Values | `nginx`, `nginx-full`, `nginx-extra`, or any other valid package that is a drop in replacement   |
+| property       | value           |
+| -------------- | --------------- |
+| Type           | [String, Array] |
+| Default        | `nil`           |
+| Allowed Values | `nginx`, `nginx-full`, `nginx-extra`, or any other valid package(s) that is/are a drop in replacement   |
 
 ### `passenger_root`
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -153,7 +153,7 @@ property :passenger_anonymous_telemetry_proxy, String,
 property :passenger_nodejs, String,
          description: 'Passenger nodejs.'
 
-property :override_package_name, String,
+property :override_package_name, [String, Array],
          description: 'forcefully specify a package name such as nginx-extras, nginx-full, etc'
 
 action :install do


### PR DESCRIPTION
# Description

Small change to allow multiple override packages to be provided for the install resource. Useful for installing optional modules along with nginx.

## Issues Resolved

- n/a

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
