### PR TITLE
Fix site containing directory creation when nginx_config is not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Fix site containing directory creation when nginx_config is not used
+
 ## 11.1.0 - *2020-12-07*
 
 - Add `repo_train` property to nginx_install to select stable/mainline when installing from the nginx repo.

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -56,14 +56,12 @@ action_class do
 end
 
 action :create do
-  unless ::Dir.exist?(::File.dirname(new_resource.conf_dir))
-    directory ::File.dirname(new_resource.conf_dir) do
-      user new_resource.user
-      group new_resource.group
-      mode '0750'
-      action :create
-    end
-  end
+  directory new_resource.conf_dir do
+    user new_resource.user
+    group new_resource.group
+    mode '0750'
+    action :create
+  end unless ::Dir.exist?(new_resource.conf_dir)
 
   template config_file do
     cookbook new_resource.cookbook


### PR DESCRIPTION
# Description

Fix site containing directory creation when nginx_config is not used.
 
## Issues Resolved

- #568 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
