### PR TITLE
Add seperate properties for nginx process user/group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Add seperate `process_*` properties for nginx process use and group to `nginx_config` resource (Issue #572)
+  - Deprecate and alias the `user` property as the `process_*` properties supercede it
+
 ## 11.2.0 - *2021-01-20*
 
 - Add file and folder mode overrides to `nginx_config` and `nginx_site`

--- a/documentation/nginx_config.md
+++ b/documentation/nginx_config.md
@@ -17,11 +17,12 @@
 | `conf_variables`       | Hash          | `{}`                             | Additional variables to include in conf template.                   |
 | `port`                 | Integer, String | `80`                           | Port to listen on.                                                  |
 | `server_name`          | String        | `node['hostname']`               | Sets the server_name directive.                                     |
-| `user`                 | String        | `nginx`                          | Nginx run-as user.                                                  |
 | `owner`                | String        | `nginx`                          | Nginx file/folder owner.                                            |
 | `group`                | String        | `nginx`                          | Nginx run-as/file/folder group.                                     |
 | `mode`                 | String        | `0640`                           | Nginx configuration file mode.                                      |
 | `folder_mode`          | String        | `0750`                           | Nginx configuration folder mode.                                    |
+| `process_user`         | String        | `nginx`                          | Nginx run-as user.                                                  |
+| `process_group`        | String        | `nginx`                          | Nginx run-as group.                                                 |
 | `worker_processes`     | Integer, String | `auto`                         | The number of worker processes.                                     |
 | `worker_connections`   | Integer, String | `1_024`                        | The maximum number of simultaneous connections that can be opened by a worker process.|
 | `sendfile`             | String        | `on`                             | Enables or disables the use of sendfile().                          |

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+deprecated_property_alias 'user',
+                          'process_user',
+                          'The user property was renamed process_user in the 11.3 release of this cookbook. Please update your cookbooks to use the new property name. This alias will be removed in the next major version.'
+
 property :config_file, String,
           description: 'The full path to the Nginx server configuration on disk.',
           default: lazy { nginx_config_file }
@@ -40,13 +44,9 @@ property :server_name, String,
           description: 'Sets the server_name directive.',
           default: lazy { node['hostname'] }
 
-property :user, String,
-          description: 'Nginx user',
-          default: lazy { nginx_user }
-
 property :owner, String,
           description: 'File/folder group',
-          default: lazy { user }
+          default: lazy { nginx_user }
 
 property :group, String,
           description: 'File/folder group',
@@ -59,6 +59,14 @@ property :mode, String,
 property :folder_mode, String,
           description: 'Folder mode',
           default: '0750'
+
+property :process_user, String,
+          description: 'Nginx process user',
+          default: lazy { nginx_user }
+
+property :process_group, String,
+          description: 'Nginx process group',
+          default: lazy { nginx_group }
 
 property :worker_processes, [Integer, String],
           description: 'The number of worker processes.',
@@ -172,8 +180,8 @@ action :create do
     variables(
       nginx_dir: nginx_dir,
       nginx_log_dir: nginx_log_dir,
-      nginx_user: new_resource.user,
-      group: new_resource.group,
+      process_user: new_resource.process_user,
+      process_group: new_resource.process_group,
       worker_processes: new_resource.worker_processes,
       pid: nginx_pid_file,
       worker_connections: new_resource.worker_connections,

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -21,8 +21,8 @@ describe 'nginx_config' do
         .with_variables(
           nginx_dir: '/etc/nginx',
           nginx_log_dir: '/var/log/nginx',
-          nginx_user: 'www-data',
-          group: 'www-data',
+          process_user: 'www-data',
+          process_group: 'www-data',
           worker_processes: 'auto',
           pid: '/run/nginx.pid',
           worker_connections: '1024',

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -2,7 +2,7 @@
 # Do NOT modify this file by hand.
 #
 
-user <%= @nginx_user %><% if @nginx_user != @group %> <%= @group %><% end %>;
+user <%= @process_user %><% if @process_group != @process_user %> <%= @process_group %><% end %>;
 worker_processes <%= @worker_processes %>;
 error_log <%= @nginx_log_dir %>/error.log;
 pid <%= @pid %>;


### PR DESCRIPTION
# Description

Add seperate properties for nginx process user/group so nginx configuration file/folder owner/group does not effect the run-as user/group.

## Issues Resolved

- Fixes #572 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
