### PR TITLE
Library refactoring and dynamic helper inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
-- Refactor ResourceHelpers library to inherit properties from the calling resource
+- Refactor `ResourceHelpers` library to inherit properties from the calling resource
+- Allow for inclusion of arbitrary template helper modules
 
 ## 11.3.1 - *2021-02-25*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Refactor ResourceHelpers library to inherit properties from the calling resource
+
 ## 11.3.1 - *2021-02-25*
 
 - Fixup the default site template and update nginx_site doc to match

--- a/documentation/nginx_config.md
+++ b/documentation/nginx_config.md
@@ -33,6 +33,7 @@
 | `default_site_enabled` | True, False   | `true`                           | Whether or not the default site is enabled.                         |
 | `default_site_cookbook`| String        | `nginx`                          | Which cookbook to use for the default site template.                |
 | `default_site_template`| String        | `default-site.erb`               | Which template to use for the default site.                         |
+| `template_helpers`     | String, Array | `nil`                            | Additional helper modules to include in the default site and config template. |
 
 ## Examples
 

--- a/documentation/nginx_site.md
+++ b/documentation/nginx_site.md
@@ -21,6 +21,7 @@
 | `mode`                 | String        | `0640`                           | Nginx configuration file mode.                                      |
 | `folder_mode`          | String        | `0750`                           | Nginx configuration folder mode.                                    |
 | `variables`            | Hash          | `{}`                             | Additional variables to include in site template                    |
+| `template_helpers`     | String, Array | `nil`                            | Additional helper modules to include in the site template           |
 
 ## Usage
 

--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -1,25 +1,25 @@
 module Nginx
   module Cookbook
     module ResourceHelpers
-      def create_list_resource(directory)
+      def create_list_resource
         with_run_context(:root) do
-          edit_resource(:directory, directory) do
+          edit_resource(:directory, new_resource.conf_dir) do |new_resource|
             owner new_resource.owner
             group new_resource.group
             mode new_resource.folder_mode
+
+            action :create
           end
 
-          edit_resource(:template, "#{directory}/list.conf") do
+          edit_resource(:template, "#{new_resource.conf_dir}/list.conf") do |new_resource|
             cookbook 'nginx'
             source 'list.conf.erb'
 
-            owner 'root'
+            owner new_resource.owner
             group new_resource.group
             mode new_resource.mode
 
-            helpers(
-              Nginx::Cookbook::TemplateHelpers
-            )
+            helpers(Nginx::Cookbook::TemplateHelpers)
 
             variables['files'] ||= []
 
@@ -29,21 +29,23 @@ module Nginx
         end
       end
 
-      def add_to_list_resource(directory, config_file)
-        manage_list_resource(directory, config_file, :add)
+      def add_to_list_resource
+        manage_list_resource(:add)
       end
 
-      def remove_from_list_resource(directory, config_file)
-        manage_list_resource(directory, config_file, :remove)
+      def remove_from_list_resource
+        manage_list_resource(:remove)
       end
 
       private
 
-      def manage_list_resource(directory, config_file, action)
+      def manage_list_resource(action)
+        raise ArgumentError, "manage_list_resource: Invalid action #{action}." unless %i(add remove).include?(action)
+
         list = begin
-                 find_resource!(:template, "#{directory}/list.conf")
+                 find_resource!(:template, "#{new_resource.conf_dir}/list.conf")
                rescue Chef::Exceptions::ResourceNotFound
-                 create_list_resource(directory)
+                 create_list_resource
                end
 
         files = list.variables['files']

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -149,25 +149,23 @@ action :create do
     end
   end
 
-  if default_site_enabled?
-    nginx_site 'default-site' do
-      cookbook new_resource.default_site_cookbook
-      template new_resource.default_site_template
-      conf_dir nginx_config_site_dir
+  nginx_site 'default-site' do
+    cookbook new_resource.default_site_cookbook
+    template new_resource.default_site_template
+    conf_dir nginx_config_site_dir
 
-      owner new_resource.owner
-      group new_resource.group
-      mode new_resource.mode
-      folder_mode new_resource.folder_mode
+    owner new_resource.owner
+    group new_resource.group
+    mode new_resource.mode
+    folder_mode new_resource.folder_mode
 
-      variables(
-        nginx_log_dir: nginx_log_dir,
-        port: new_resource.port,
-        server_name: new_resource.server_name,
-        default_root: default_root
-      ).merge!(new_resource.default_site_variables)
-    end
-  end
+    variables(
+      nginx_log_dir: nginx_log_dir,
+      port: new_resource.port,
+      server_name: new_resource.server_name,
+      default_root: default_root
+    ).merge!(new_resource.default_site_variables)
+  end if default_site_enabled?
 
   template new_resource.config_file do
     cookbook new_resource.conf_cookbook

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -120,6 +120,10 @@ property :default_site_variables, Hash,
           description: 'Additional variables to include in default site template.',
           default: {}
 
+property :template_helpers, [String, Array],
+          description: 'Additional helper modules to include in the default site and config template',
+          coerce: proc { |p| p.is_a?(Array) ? p : [p] }
+
 action_class do
   include Nginx::Cookbook::ResourceHelpers
 
@@ -159,6 +163,8 @@ action :create do
     mode new_resource.mode
     folder_mode new_resource.folder_mode
 
+    template_helpers new_resource.template_helpers
+
     variables(
       nginx_log_dir: nginx_log_dir,
       port: new_resource.port,
@@ -175,9 +181,8 @@ action :create do
     group new_resource.group
     mode new_resource.mode
 
-    helpers(
-      Nginx::Cookbook::TemplateHelpers
-    )
+    helpers(Nginx::Cookbook::TemplateHelpers)
+    new_resource.template_helpers.each { |th| helpers(::Object.const_get(th)) } unless new_resource.template_helpers.nil?
 
     variables(
       nginx_dir: nginx_dir,

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -55,6 +55,10 @@ property :list, [true, false],
           description: 'Include in list resource',
           default: true
 
+property :template_helpers, [String, Array],
+          description: 'Additional helper modules to include in the site template',
+          coerce: proc { |p| p.is_a?(Array) ? p : [p] }
+
 action_class do
   include Nginx::Cookbook::ResourceHelpers
 
@@ -84,9 +88,8 @@ action :create do
     group new_resource.group
     mode new_resource.mode
 
-    helpers(
-      Nginx::Cookbook::TemplateHelpers
-    )
+    helpers(Nginx::Cookbook::TemplateHelpers)
+    new_resource.template_helpers.each { |th| helpers(::Object.const_get(th)) } unless new_resource.template_helpers.nil?
 
     variables(
       new_resource.variables.merge({ name: new_resource.name })

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -16,7 +16,7 @@
 #
 
 property :conf_dir, String,
-          description: 'Which site to enable or disable.',
+          description: 'The directory to create the site configuraiton file in.',
           default: lazy { nginx_config_site_dir }
 
 property :cookbook, String,
@@ -95,10 +95,7 @@ action :create do
     action :create
   end
 
-  add_to_list_resource(
-    new_resource.conf_dir,
-    config_file
-  ) if new_resource.list
+  add_to_list_resource if new_resource.list
 end
 
 action :delete do
@@ -106,17 +103,11 @@ action :delete do
     action :delete
   end
 
-  remove_from_list_resource(
-    new_resource.conf_dir,
-    config_file
-  ) if new_resource.list
+  remove_from_list_resource if new_resource.list
 end
 
 action :enable do
-  add_to_list_resource(
-    new_resource.conf_dir,
-    config_file
-  ) if new_resource.list
+  add_to_list_resource if new_resource.list
 
   ruby_block "Enable site #{new_resource.name}" do
     block { ::File.rename(config_file_disabled, config_file) }
@@ -129,10 +120,7 @@ action :enable do
 end
 
 action :disable do
-  remove_from_list_resource(
-    new_resource.conf_dir,
-    config_file
-  ) if new_resource.list
+  remove_from_list_resource if new_resource.list
 
   ruby_block "Disable site #{new_resource.name}" do
     block { ::File.rename(config_file, config_file_disabled) }


### PR DESCRIPTION
# Description

- Ran into a few weird edge cases. Refactored the `ResourceHelpers` library to inherit all of the automatic resource properties from the calling resource.
- Allow for inclusion of arbitrary template helper modules in the site templates

## Issues Resolved

- n/a

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
