### PR TITLE
Remove rbrace nobody matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Fix site template: remove unmatching rbrace in options
+
 ## 11.5.2 - *2021-04-16*
 
 ## 11.5.1 - *2021-03-29*

--- a/templates/default/site-template.erb
+++ b/templates/default/site-template.erb
@@ -103,5 +103,4 @@ map <%= name %> {
 <% @options.each do |option, value| -%>
 <%= option %> <%= value %>;
 <% end -%>
-}
 <% end -%>


### PR DESCRIPTION
# Description

This rbrace has no matching lbrace.

## Issues Resolved

It causes nginx config error with `options` for the template.

```
nginx: [emerg] unexpected "}" in /etc/nginx/conf.http.d/myoptions.conf
```

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
