### PR TITLE
Only trigger ohai refresh on plugin installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Only trigger ohai refresh on plugin installation
+
 ## 12.0.2 - *2021-05-11*
 
 ## 12.0.1 - *2021-05-10*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## 12.0.2 - *2021-05-11*
 
+- Standardise files with files in sous-chefs/repo-management
+
 ## 12.0.1 - *2021-05-10*
 
 - Refactor the default site template

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -75,7 +75,7 @@ action :install do
     end
 
     ohai 'nginx' do
-      action :reload
+      action :nothing
     end
   end
 

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -11,7 +11,7 @@ describe 'nginx_install' do
 
   context 'with default properties' do
     shared_examples_for 'ohai is enabled' do
-      it { is_expected.to reload_ohai('nginx') }
+      it { expect(chef_run.ohai('nginx')).to do_nothing }
       it { is_expected.to create_template(%r{/ohai/plugins/nginx.rb}).with_variables(binary: '/usr/sbin/nginx') }
     end
 


### PR DESCRIPTION
# Description

Only trigger ohai refresh on plugin installation

## Issues Resolved

- n/a

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
