### PR TITLE
Correct default value for `config_dir` in nginx_site.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Correct default value for `config_dir` in nginx_site.md
+
 ## 12.0.6 - *2021-09-04*
 
 - Fix repo helper incorrect version for SLES

--- a/documentation/nginx_site.md
+++ b/documentation/nginx_site.md
@@ -11,17 +11,17 @@
 
 ## Properties
 
-| Name               | Type          | Default                   | Description                                               |
-| ------------------ | ------------- | ------------------------- | --------------------------------------------------------- |
-| `config_dir`       | String        | `/etc/nginx/conf.sites.d` | Directory to create configuration file in                 |
-| `cookbook`         | String        | `nginx`                   | Cookbook to source configuration file template from       |
-| `template`         | String        | `site-template.erb`       | Template to use to generate the configuration file        |
-| `owner`            | String        | `nginx`                   | Nginx configuration file/folder owner.                    |
-| `group`            | String        | `nginx`                   | Nginx configuration file/folder group.                    |
-| `mode`             | String        | `0640`                    | Nginx configuration file mode.                            |
-| `folder_mode`      | String        | `0750`                    | Nginx configuration folder mode.                          |
-| `variables`        | Hash          | `{}`                      | Additional variables to include in site template          |
-| `template_helpers` | String, Array | `nil`                     | Additional helper modules to include in the site template |
+| Name               | Type          | Default                  | Description                                               |
+|--------------------|---------------|--------------------------|-----------------------------------------------------------|
+| `config_dir`       | String        | `/etc/nginx/conf.http.d` | Directory to create configuration file in                 |
+| `cookbook`         | String        | `nginx`                  | Cookbook to source configuration file template from       |
+| `template`         | String        | `site-template.erb`      | Template to use to generate the configuration file        |
+| `owner`            | String        | `nginx`                  | Nginx configuration file/folder owner.                    |
+| `group`            | String        | `nginx`                  | Nginx configuration file/folder group.                    |
+| `mode`             | String        | `0640`                   | Nginx configuration file mode.                            |
+| `folder_mode`      | String        | `0750`                   | Nginx configuration folder mode.                          |
+| `variables`        | Hash          | `{}`                     | Additional variables to include in site template          |
+| `template_helpers` | String, Array | `nil`                    | Additional helper modules to include in the site template |
 
 ## Usage
 


### PR DESCRIPTION
Signed-off-by: Joshua Colson <joshua.colson@gmail.com>

# Description

Resolve minor error in the documentation of `nginx_site.md`

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
