### PR TITLE
Change the unit tested Debian platform to bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Change the unit tested Debian platform to bullseye
+
 ## 12.0.8 - *2021-11-23*
 
 - Rename `config_dir` to `conf_dir` in nginx_site.md

--- a/spec/support/install.rb
+++ b/spec/support/install.rb
@@ -20,7 +20,7 @@ end
 def platform_distribution_nginx
   case chefspec_platform
   when 'debian'
-    'buster'
+    'bullseye'
   when 'ubuntu'
     'focal'
   end


### PR DESCRIPTION
Changes the unit tested Debian platform to bullseye so that the unit tests now pass

Signed-off-by: Dan Webb <dan.webb@damacus.io>
