### PR TITLE
Security fixes to address #604

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+- Security fixes
+  - Fix nginx running as root on Debian family
+  - Fix webserver able to overwrite/delete config files
+  - Add Inspec tests
+
 ## 12.0.12 - *2022-04-20*
 
 Standardise files with files in sous-chefs/repo-management

--- a/documentation/nginx_config.md
+++ b/documentation/nginx_config.md
@@ -17,12 +17,12 @@
 | `conf_variables`       | Hash          | `{}`                             | Additional variables to include in conf template.                   |
 | `port`                 | Integer, String | `80`                           | Port to listen on.                                                  |
 | `server_name`          | String        | `node['hostname']`               | Sets the server_name directive.                                     |
-| `owner`                | String        | `nginx`                          | Nginx file/folder owner.                                            |
-| `group`                | String        | `nginx`                          | Nginx run-as/file/folder group.                                     |
+| `owner`                | String        | `root`                           | Nginx file/folder owner.                                            |
+| `group`                | String        | `root`                           | Nginx run-as/file/folder group.                                     |
 | `mode`                 | String        | `0640`                           | Nginx configuration file mode.                                      |
 | `folder_mode`          | String        | `0750`                           | Nginx configuration folder mode.                                    |
-| `process_user`         | String        | `nginx`                          | Nginx run-as user.                                                  |
-| `process_group`        | String        | `nginx`                          | Nginx run-as group.                                                 |
+| `process_user`         | String        | `www-data` (Debian) or `nginx`   | Nginx run-as user.                                                  |
+| `process_group`        | String        | `www-data` (Debian) or `nginx`   | Nginx run-as group.                                                 |
 | `worker_processes`     | Integer, String | `auto`                         | The number of worker processes.                                     |
 | `worker_connections`   | Integer, String | `1_024`                        | The maximum number of simultaneous connections that can be opened by a worker process.|
 | `sendfile`             | String        | `on`                             | Enables or disables the use of sendfile().                          |

--- a/documentation/nginx_site.md
+++ b/documentation/nginx_site.md
@@ -16,8 +16,8 @@
 | `conf_dir`         | String        | `/etc/nginx/conf.http.d` | Directory to create configuration file in                 |
 | `cookbook`         | String        | `nginx`                  | Cookbook to source configuration file template from       |
 | `template`         | String        | `site-template.erb`      | Template to use to generate the configuration file        |
-| `owner`            | String        | `nginx`                  | Nginx configuration file/folder owner.                    |
-| `group`            | String        | `nginx`                  | Nginx configuration file/folder group.                    |
+| `owner`            | String        | `root`                   | Nginx configuration file/folder owner.                    |
+| `group`            | String        | `root`                   | Nginx configuration file/folder group.                    |
 | `mode`             | String        | `0640`                   | Nginx configuration file mode.                            |
 | `folder_mode`      | String        | `0750`                   | Nginx configuration folder mode.                          |
 | `variables`        | Hash          | `{}`                     | Additional variables to include in site template          |

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,7 +16,7 @@ module Nginx
           when 'centos'
             "#{repo_base_url}/centos/#{node['platform_version'].to_i}/$basearch"
           when 'fedora'
-            "#{repo_base_url}/rhel/8/$basearch"
+            "#{repo_base_url}/rhel/9/$basearch"
           else
             "#{repo_base_url}/rhel/#{node['platform_version'].to_i}/$basearch"
           end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -40,11 +40,11 @@ module Nginx
       end
 
       def nginx_user
-        platform_family?('debian') ? 'root' : 'nginx'
+        platform_family?('debian') ? 'www-data' : 'nginx'
       end
 
       def nginx_group
-        platform_family?('debian') ? 'root' : 'nginx'
+        platform_family?('debian') ? 'www-data' : 'nginx'
       end
 
       def nginx_pid_file

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -49,12 +49,12 @@ property :server_name, String,
           default: lazy { node['hostname'] }
 
 property :owner, String,
-          description: 'File/folder group',
-          default: lazy { nginx_user }
+          description: 'File/folder user',
+          default: 'root'
 
 property :group, String,
           description: 'File/folder group',
-          default: lazy { nginx_group }
+          default: 'root'
 
 property :mode, String,
           description: 'File mode',

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -33,11 +33,11 @@ property :template, [String, Array],
 
 property :owner, String,
           description: 'File/folder user',
-          default: lazy { nginx_user }
+          default: 'root'
 
 property :group, String,
           description: 'File/folder group',
-          default: lazy { nginx_group }
+          default: 'root'
 
 property :mode, String,
           description: 'File mode',

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Nginx::Cookbook::Helpers do
       let(:platform_family) { 'fedora' }
       let(:platform) { 'fedora' }
 
-      it { expect(subject.repo_url).to eq 'https://nginx.org/packages/rhel/8/$basearch' }
+      it { expect(subject.repo_url).to eq 'https://nginx.org/packages/rhel/9/$basearch' }
     end
 
     context 'with debian family stable' do
@@ -141,7 +141,7 @@ RSpec.describe Nginx::Cookbook::Helpers do
       let(:platform_family) { 'fedora' }
       let(:platform) { 'fedora' }
 
-      it { expect(subject.repo_url('mainline')).to eq 'https://nginx.org/packages/mainline/rhel/8/$basearch' }
+      it { expect(subject.repo_url('mainline')).to eq 'https://nginx.org/packages/mainline/rhel/9/$basearch' }
     end
 
     context 'with debian family mainline' do

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Nginx::Cookbook::Helpers do
     context 'with debian family' do
       let(:platform_family) { 'debian' }
 
-      it { expect(subject.nginx_user).to eq 'root' }
+      it { expect(subject.nginx_user).to eq 'www-data' }
     end
 
     context 'with fedora family' do
@@ -247,7 +247,7 @@ RSpec.describe Nginx::Cookbook::Helpers do
     context 'with debian family' do
       let(:platform_family) { 'debian' }
 
-      it { expect(subject.nginx_group).to eq 'root' }
+      it { expect(subject.nginx_group).to eq 'www-data' }
     end
 
     context 'with fedora family' do

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -47,7 +47,7 @@ describe 'nginx_config' do
         )
     end
 
-    it { is_expected.to create_directory('/var/log/nginx').with_mode('0750').with_owner('nginx') }
+    it { is_expected.to create_directory('/var/log/nginx').with_mode('0750').with_owner('root') }
     it { is_expected.to create_directory('/etc/nginx/conf.d').with_mode('0750') }
     it { is_expected.to create_directory('/etc/nginx/conf.http.d').with_mode('0750') }
   end

--- a/test/integration/default/config_test.rb
+++ b/test/integration/default/config_test.rb
@@ -29,9 +29,19 @@ end
   end
 end
 
+process_owner = case os.family
+                when 'debian'
+                  'www-data'
+                else
+                  'nginx'
+                end
+
 describe file('/etc/nginx/nginx.conf') do
   it { should exist }
   it { should be_file }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('content') { should match(/user\s+#{process_owner};/) }
   its('content') { should include 'worker_processes      auto;' }
   its('content') { should include 'pid                   /run/nginx.pid;' }
   its('content') { should include 'worker_connections  1024;' }
@@ -45,6 +55,8 @@ end
 describe file('/etc/nginx/conf.http.d/default-site.conf') do
   it { should exist }
   it { should be_file }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
   its('content') { should include 'listen       80;' }
   its('content') { should include 'access_log   /var/log/nginx/localhost.access.log;' }
   case os.family


### PR DESCRIPTION
Fix nginx running as root on Debian family
Fix webserver able to overwrite/delete config files
Add Inspec tests

# Description

This PR partly reverts #593 that caused nginx to run as root on Debian platform family. It also makes sure that all configuration files are written as `root:root` so the webserver has no permission to alter or delete its own configuration.

## Issues Resolved

#604
#591 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
