### PR TITLE
Remove Fedora Linux from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           - "centos-stream-9"
           - "debian-10"
           - "debian-11"
-          - "fedora-latest"
           - "opensuse-leap-15"
           - "rockylinux-8"
           - "rockylinux-9"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 ## Unreleased
 
+Remove Fedora Linux from test matrix
+
 ## 12.2.5 - *2023-09-28*
 
 ## 12.2.4 - *2023-09-28*


### PR DESCRIPTION
Fedora has changed the location of where the binary is located. 

If anyone wants to re-add this, then please be my guest. 